### PR TITLE
Use leaf::e_source_location for stacktrace

### DIFF
--- a/include/libembeddedhal/internal/third_party/leaf.hpp
+++ b/include/libembeddedhal/internal/third_party/leaf.hpp
@@ -1125,9 +1125,9 @@ namespace boost { namespace leaf {
 
 struct e_source_location
 {
-    char const * const file;
-    int const line;
-    char const * const function;
+    char const * file;
+    int line;
+    char const * function;
 
     template <class CharT, class Traits>
     friend std::basic_ostream<CharT, Traits> & operator<<( std::basic_ostream<CharT, Traits> & os, e_source_location const & x )
@@ -3394,7 +3394,7 @@ namespace leaf_detail
         {
             return 0;
         }
-        
+
         template <class SlotsTuple>
         BOOST_LEAF_CONSTEXPR static E * peek( SlotsTuple &, error_id const & ) noexcept
         {


### PR DESCRIPTION
LEAF was updated to remove the const members in e_source_location which
allows coping of the structure. Rather than making an additional type,
leaf::e_source_location can be reused.