### PR TITLE
Remove internal conan usage for cmake test

### DIFF
--- a/include/libembeddedhal/error.hpp
+++ b/include/libembeddedhal/error.hpp
@@ -171,7 +171,7 @@ auto setup(
  * function return int of value 0.
  */
 template<typename T>
-constexpr auto&& get_return_value(boost::leaf::result<T>& p_result)
+constexpr auto get_return_value(boost::leaf::result<T>& p_result)
 {
   if constexpr (std::is_void_v<T>) {
     return 0;

--- a/include/libembeddedhal/full_scale.hpp
+++ b/include/libembeddedhal/full_scale.hpp
@@ -146,7 +146,7 @@ constexpr static T increase_bit_depth(U p_value)
   T result = static_cast<T>(p_value) << width_difference;
 
   if (p_value > 0) {
-    for (int i = final_source_width; i < final_width_difference;
+    for (size_t i = final_source_width; i < final_width_difference;
          i += final_source_width) {
       result |= (result >> i);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,10 +17,6 @@ endif()
 
 include(${CMAKE_BINARY_DIR}/conan.cmake)
 
-conan_cmake_run(REQUIRES libembeddedhal/0.0.1
-                BASIC_SETUP CMAKE_TARGETS
-                BUILD missing)
-
 conan_cmake_run(REQUIRES boost-ext-ut/1.1.8
                 BASIC_SETUP CMAKE_TARGETS
                 BUILD missing)
@@ -36,10 +32,11 @@ add_executable(${PROJECT_NAME}
     main.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
+target_compile_options(${PROJECT_NAME} PRIVATE -Werror -Wall -Wextra)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_VISIBILITY_PRESET default)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(${PROJECT_NAME} PRIVATE
-    CONAN_PKG::libembeddedhal
     CONAN_PKG::boost-ext-ut)


### PR DESCRIPTION
Using conan as a package means it gets included as a -isystem header.
This will prevent warnings from the library files from being emitted. To
get those back conan packages cannot be used in this way.