### PR TITLE
Change timer to be more like a timer

### DIFF
--- a/include/libembeddedhal/i2c/i2c.hpp
+++ b/include/libembeddedhal/i2c/i2c.hpp
@@ -61,6 +61,7 @@ public:
    */
   struct address_not_acknowledged
   {};
+
   /**
    * @brief Error type indicating that the i2c lines were put into an invalid
    * state during the transaction due to interference, misconfiguration of the


### PR DESCRIPTION
Looking at java.util.Timer, SysTick Timer, and JavaScript Timers one
can see that a timer is meant for one purpose and that is to do
something when a time has elapsed. All of the other controls do not
make much sense.

The interface has been reduced down to 3 core functions:

- is_running()
- clear()
- schedule()

Resolves #44