### PR TITLE
can & config fix up + new serial error object

### DIFF
--- a/include/libembeddedhal/can/can.hpp
+++ b/include/libembeddedhal/can/can.hpp
@@ -54,23 +54,6 @@ public:
   virtual boost::leaf::result<void> send(const message_t& p_message) = 0;
 
   /**
-   * @brief Determine if the can bus has any queued up can messages
-   *
-   * @return boost::leaf::result<bool> - true if a can message is available to
-   * read, false otherwise.
-   */
-  virtual boost::leaf::result<bool> has_data() = 0;
-
-  /**
-   * @brief Receieve a message from the can bus if one is available.
-   *
-   * Behavior is undefined if no data is available.
-   *
-   * @return boost::leaf::result<message_t> - a can message from the bus
-   */
-  virtual boost::leaf::result<message_t> receive() = 0;
-
-  /**
    * @brief Setup driver to execute callback when a can message is received.
    *
    * @param p_receive_handler - this handler will be called when the can device

--- a/include/libembeddedhal/config.hpp
+++ b/include/libembeddedhal/config.hpp
@@ -17,19 +17,19 @@ using namespace defaults;
 #include <libembeddedhal.tweaks.hpp>
 #endif
 
-namespace embed::config {
+namespace embed {
 /**
  * @brief Determines if the current application was built for a specific
  * platform. For example:
  *
- *    embed::config::is_platform("lpc4078");
+ *    embed::is_platform("lpc4078");
  *
  * Will return true if the PLATFORM macro defined at compile time was equal to
  * lpc4078. If the developer wants to be less specific, let say, to just
  * determine if the platform is in the lpc40xx family then the following example
  * will work.
  *
- *    embed::config::is_platform("lpc40");
+ *    embed::is_platform("lpc40");
  *
  * @param p_platform - platform string pattern to check against
  * @return true - matches the platform string
@@ -37,7 +37,7 @@ namespace embed::config {
  */
 constexpr bool is_platform(std::string_view p_platform)
 {
-  return platform.starts_with(p_platform);
+  return config::platform.starts_with(p_platform);
 }
 
 /**
@@ -48,7 +48,8 @@ constexpr bool is_platform(std::string_view p_platform)
  */
 constexpr bool is_a_test()
 {
-  return (platform.starts_with("unit_test") ||
-          platform.starts_with("unittest") || platform.starts_with("test"));
+  return (config::platform.starts_with("unit_test") ||
+          config::platform.starts_with("unittest") ||
+          config::platform.starts_with("test"));
 }
-};  // namespace embed::config
+};  // namespace embed

--- a/include/libembeddedhal/serial/serial.hpp
+++ b/include/libembeddedhal/serial/serial.hpp
@@ -8,74 +8,38 @@
 #include <span>
 
 namespace embed {
-/**
- * @brief Generic settings for a standard serial device.
- *
- */
+/// Generic settings for a standard serial device.
 struct serial_settings
 {
-  /**
-   * @brief Set of available stop bits options
-   *
-   */
+  /// Set of available stop bits options
   enum class stop_bits : uint8_t
   {
     one = 0,
     two,
   };
 
-  /**
-   * @brief Set of parity bit options
-   *
-   */
+  /// Set of parity bit options
   enum class parity : uint8_t
   {
-    /**
-     * @brief Disable parity bit as part of the frame
-     *
-     */
+    /// Disable parity bit as part of the frame
     none = 0,
-    /**
-     * @brief Enable parity and set 1 (HIGH) when the number of bits is odd
-     *
-     */
+    /// Enable parity and set 1 (HIGH) when the number of bits is odd
     odd,
-    /**
-     * @brief Enable parity and set 1 (HIGH) when the number of bits is even
-     *
-     */
+    /// Enable parity and set 1 (HIGH) when the number of bits is even
     even,
-    /**
-     * @brief Enable parity bit and always return 1 (HIGH) for ever frame
-     *
-     */
+    /// Enable parity bit and always return 1 (HIGH) for ever frame
     forced1,
-    /**
-     * @brief Enable parity bit and always return 0 (LOW) for ever frame
-     *
-     */
+    /// Enable parity bit and always return 0 (LOW) for ever frame
     forced0,
   };
 
-  /**
-   * @brief The operating speed of the baud rate (in units of bits per second)
-   *
-   */
+  /// The operating speed of the baud rate (in units of bits per second)
   uint32_t baud_rate = 115200;
-  /**
-   * @brief Parity bit type for each frame
-   *
-   */
+  /// Parity bit type for each frame
   parity parity = parity::none;
-  /**
-   * @brief Number of stop bits for each frame
-   *
-   */
+  /// Number of stop bits for each frame
   stop_bits stop = stop_bits::one;
-  /**
-   * @brief Number of bits in each frame. Typically between 5 to 9.
-   *
-   */
+  /// Number of bits in each frame. Typically between 5 to 9.
   uint8_t frame_size = 8;
 };
 
@@ -112,9 +76,9 @@ public:
    *   treat the ones at the end as lost packets.
    *
    * - In most other cases where data lost was crucial, then the whole buffer
-   *   may need to be flushed and the data recieved again.
+   *   may need to be flushed and the data received again.
    *
-   * - A way to fix this is to enlarge the recieve buffer. This can be done with
+   * - A way to fix this is to enlarge the receive buffer. This can be done with
    *   dynamic memory allocation, but generally, its better to simply increase
    *   the buffer size by updating the application rather than growing with
    *   need.
@@ -164,6 +128,20 @@ public:
     /// The number of bytes the serial port has buffered up.
     size_t bytes_available;
   };
+
+  /**
+   * @brief Error type indicating that the settings for serial uart could not be
+   * set
+   *
+   * <b>How to handle these errors:</b>
+   *
+   * - The nature of this error signifies an bug in the code. The documentation
+   *   of the peripheral and the API of the driver should be consulted in order
+   *   to determine what are possible settings for this serial port.
+   *
+   */
+  struct invalid_settings
+  {};
 
   /**
    * @brief Write data on the transmitter line of the port. This function will


### PR DESCRIPTION
- Remove reception functions from embed::can 
- Fix issue with ambiguous access to platform string 
- Add "invalid_settings" error type for serial