### PR TITLE
Add embed::percent::to_string

### DIFF
--- a/include/libembeddedhal/math.hpp
+++ b/include/libembeddedhal/math.hpp
@@ -4,33 +4,6 @@
 
 namespace embed {
 /**
- * @brief Perform integer division and round the value up if the next decimal
- * place is greater than or equal to 0.5.
- *
- * @tparam T - integral type of the two operands
- * @param p_numerator - the value to be divided
- * @param p_denominator - the value to divide the numerator against
- * @return constexpr T - rounded quotent between numerator and denominator.
- * Returns 0 if the denominator is greater than the numerator.
- */
-template<std::integral T>
-constexpr T rounding_division(T p_numerator, T p_denominator)
-{
-  if (p_numerator < p_denominator) {
-    return 0;
-  }
-
-  const T remainder = p_numerator % p_denominator;
-  const T half_denominator = (p_denominator / 2);
-  T quotient = p_numerator / p_denominator;
-  // Round if remainder is greater than half of the denominator
-  if (half_denominator != 0 && remainder >= half_denominator) {
-    quotient++;
-  }
-  return quotient;
-}
-
-/**
  * @brief Generic absolute value function that works for integer types. This is
  * preferred over the C API for rounding numbers such as abs(), labs() and
  * llabs(). This function relieves the need in template code to check the type
@@ -45,6 +18,40 @@ constexpr auto absolute_value(std::integral auto p_value)
     return p_value;
   } else {
     return p_value * -1;
+  }
+}
+
+/**
+ * @brief Perform integer division and round the value up if the next decimal
+ * place is greater than or equal to 0.5.
+ *
+ * @tparam T - integral type of the two operands
+ * @param p_numerator - the value to be divided
+ * @param p_denominator - the value to divide the numerator against
+ * @return constexpr T - rounded quotent between numerator and denominator.
+ * Returns 0 if the denominator is greater than the numerator.
+ */
+template<std::integral T>
+constexpr T rounding_division(T p_numerator, T p_denominator)
+{
+  bool num_sign = p_numerator > 0;
+  bool den_sign = p_denominator > 0;
+
+  auto numerator = absolute_value(p_numerator);
+  auto denominator = absolute_value(p_denominator);
+
+  const T remainder = numerator % denominator;
+  const T half_denominator = (denominator / 2);
+  T quotient = numerator / denominator;
+  // Round if remainder is greater than half of the denominator
+  if (half_denominator != 0 && remainder >= half_denominator) {
+    quotient++;
+  }
+
+  if (num_sign == den_sign) {
+    return quotient;
+  } else {
+    return -quotient;
   }
 }
 }  // namespace embed

--- a/include/libembeddedhal/to_array.hpp
+++ b/include/libembeddedhal/to_array.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string_view>
+
+namespace embed {
+/**
+ * @brief Convert a string_view into a std::array of N number of characters.
+ *
+ * Will always ensure that the array is null terminated
+ *
+ * @tparam N - Size of the array
+ * @param p_view - string to be placed into a char array
+ * @return constexpr std::array<char, N + 1> - the char array object
+ */
+template<size_t N>
+constexpr std::array<char, N + 1> to_array(std::string_view p_view)
+{
+  const size_t min = std::min(N, p_view.size());
+  std::array<char, N + 1> result;
+
+  auto out_iterator = std::copy_n(p_view.begin(), min, result.begin());
+  std::fill(out_iterator, result.end(), '\0');
+
+  return result;
+}
+}  // namespace embed

--- a/tests/percent.test.cpp
+++ b/tests/percent.test.cpp
@@ -259,4 +259,109 @@ boost::ut::suite percent_signed_test = []() {
     // Exercise
   };
 };
+
+boost::ut::suite percent_to_string_test = []() {
+  using namespace boost::ut;
+
+  percent value;
+  std::string_view expected_string;
+  decltype(value.to_string()) string;
+
+  auto get_actual_string = [&]() -> std::string_view {
+    string = value.to_string();
+    return std::string_view(string.data(), string.size() - 1);
+  };
+
+  // Check positive boundary
+  value = +1.000000000;
+  expect(get_actual_string() == std::string_view{ "+1.000000000" });
+
+  // Check zero
+  value = +0.000000000;
+  expect(get_actual_string() == std::string_view{ "+0.000000000" });
+
+  // Check negative boundary
+  value = -1.000000000;
+  expect(get_actual_string() == std::string_view{ "-1.000000000" });
+
+  // Check various positive numbers
+  value = +0.999999998;
+  expect(get_actual_string() == std::string_view{ "+0.999999998" });
+
+  value = +0.999999995;
+  expect(get_actual_string() == std::string_view{ "+0.999999995" });
+
+  value = +0.500000000;
+  expect(get_actual_string() == std::string_view{ "+0.500000000" });
+
+  value = +0.444000000;
+  expect(get_actual_string() == std::string_view{ "+0.444000000" });
+
+  value = +0.234000000;
+  expect(get_actual_string() == std::string_view{ "+0.234000000" });
+
+  value = +0.000000005;
+  expect(get_actual_string() == std::string_view{ "+0.000000005" });
+
+  value = +0.000000002;
+  expect(get_actual_string() == std::string_view{ "+0.000000002" });
+
+  value = +0.000333000;
+  expect(get_actual_string() == std::string_view{ "+0.000333000" });
+
+  // Test various negative numbers
+  value = -0.999999998;
+  expect(get_actual_string() == std::string_view{ "-0.999999998" });
+
+  value = -0.999999995;
+  expect(get_actual_string() == std::string_view{ "-0.999999995" });
+
+  value = -0.500000000;
+  expect(get_actual_string() == std::string_view{ "-0.500000000" });
+
+  value = -0.444000000;
+  expect(get_actual_string() == std::string_view{ "-0.444000000" });
+
+  value = -0.234000000;
+  expect(get_actual_string() == std::string_view{ "-0.234000000" });
+
+  value = -0.000000005;
+  expect(get_actual_string() == std::string_view{ "-0.000000005" });
+
+  value = -0.000000002;
+  expect(get_actual_string() == std::string_view{ "-0.000000002" });
+
+  value = -0.000333000;
+  expect(get_actual_string() == std::string_view{ "-0.000333000" });
+
+  // Edge cases
+
+  // Percentage is effectively zero
+  value = percent::from_ratio(1, 2147483647);
+  expect(get_actual_string() == std::string_view{ "+0.000000000" });
+
+  value = percent::from_ratio(-1, 2147483647);
+  expect(get_actual_string() == std::string_view{ "-0.000000000" });
+
+  // Percentage is effectively 1
+  value = percent::from_ratio(2, 2147483647);
+  expect(get_actual_string() == std::string_view{ "+0.000000001" });
+
+  value = percent::from_ratio(-2, 2147483647);
+  expect(get_actual_string() == std::string_view{ "-0.000000001" });
+
+  // Percentage is effectively 100%
+  value = percent::from_ratio(2147483645, 2147483647);
+  expect(get_actual_string() == std::string_view{ "+1.000000000" });
+
+  value = percent::from_ratio(-2147483645, 2147483647);
+  expect(get_actual_string() == std::string_view{ "-1.000000000" });
+
+  // Percentage is effectively 99.9...%
+  value = percent::from_ratio(2147483644, 2147483647);
+  expect(get_actual_string() == std::string_view{ "+0.999999999" });
+  // Percentage is effectively 99.9...%
+  value = percent::from_ratio(-2147483644, 2147483647);
+  expect(get_actual_string() == std::string_view{ "-0.999999999" });
+};
 }  // namespace embed


### PR DESCRIPTION
- An efficient way to convert a percent value to a std::array<char,N>
  (or a fixed sized string array).