### PR TITLE
Add overflow_counter

### DIFF
--- a/include/libembeddedhal/bit_limits.hpp
+++ b/include/libembeddedhal/bit_limits.hpp
@@ -15,7 +15,7 @@ template<size_t BitWidth, std::integral T>
 static consteval T generate_field_of_ones()
 {
   T result = 0;
-  for (int i = 0; i < BitWidth; i++) {
+  for (size_t i = 0; i < BitWidth; i++) {
     result |= 1 << i;
   }
   return result;

--- a/include/libembeddedhal/overflow_counter.hpp
+++ b/include/libembeddedhal/overflow_counter.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "bit_limits.hpp"
+
+namespace embed {
+/**
+ * @brief Extend a counter's count from an arbitrary bit width to 64-bits by
+ * detecting overflows in the count. Each detected overflow is added to an
+ * overflow counter which is combined with the current count in order create a
+ * count up to 64-bits in length.
+ *
+ * @tparam CountBitWidth - the bit width of the counter before the count value
+ * overflows.
+ */
+template<size_t CountBitWidth = 32>
+class overflow_counter
+{
+public:
+  static_assert(CountBitWidth <= 32, "Bit width cannot exceed 32-bits");
+  static_assert(CountBitWidth > 1, "Bit width must be greater than 1");
+
+  /**
+   * @brief update the overflow counter, detect if an overflow has occurred, and
+   * return the combined
+   *
+   * @param new_count - must be an increasing value and should only decrease
+   * when an overflow event occurs.
+   * @return constexpr uint64_t - 64-bit count combining the new count value and
+   * the overflow count value.
+   */
+  constexpr uint64_t update(uint32_t new_count)
+  {
+    // Sanitize the new count value to make sure it does not exceed the
+    // designated bit width. Without this check when the count is combined with
+    // the overflow value the upper bits may effect the bits of the overflow
+    // count, getting an incorrect count value.
+    constexpr auto mask = generate_field_of_ones<CountBitWidth, uint32_t>();
+    new_count = new_count & mask;
+
+    // Detect the overflow by checking if the new count is smaller than the
+    // previous count. If the count is always increasing, the only way for the
+    // new count to be smaller is if the count reached the end of its bit width
+    // and overflowed.
+    if (m_previous_count > new_count) {
+      m_overflow_count++;
+    }
+
+    // Set previous count to the new count
+    m_previous_count = new_count;
+
+    // Move overflow count up to the upper bits of the 64-bit number based on
+    // CountBitWidth
+    uint64_t combined_count = m_overflow_count;
+    combined_count <<= CountBitWidth;
+    // Add the new_count into the combined count to complete it.
+    combined_count |= new_count;
+
+    return combined_count;
+  }
+
+  /**
+   * @brief Reset the overflow count back to zero.
+   *
+   */
+  constexpr void reset()
+  {
+    m_previous_count = 0;
+    m_overflow_count = 0;
+  }
+
+private:
+  uint32_t m_previous_count = 0;
+  uint64_t m_overflow_count = 0;
+};
+}  // namespace embed

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(${PROJECT_NAME}
     timer/timer.test.cpp
     i2c/i2c.test.cpp
     time.test.cpp
+    overflow_counter.test.cpp
     static_callable.test.cpp
     imu/accelerometer.test.cpp
     imu/gyroscope.test.cpp

--- a/tests/frequency.test.cpp
+++ b/tests/frequency.test.cpp
@@ -13,13 +13,6 @@ std::ostream& operator<<(std::ostream& os, const duty_cycle& p_duty)
   return (os << "duty_cycle { high: " << p_duty.high << ","
              << " low: " << p_duty.low << " }");
 }
-// template<typename Rep, typename Period>
-// std::ostream& operator<<(std::ostream& os, const std::chrono::duration<Rep,
-// Period>& p_duty)
-// {
-//   return (os << "duty_cycle { high: " << p_duty.high << ","
-//              << " low: " << p_duty.low << " }");
-// }
 
 boost::ut::suite frequency_user_defined_literals_test = []() {
   using namespace boost::ut;

--- a/tests/overflow_counter.test.cpp
+++ b/tests/overflow_counter.test.cpp
@@ -1,0 +1,109 @@
+#include <boost/ut.hpp>
+#include <libembeddedhal/overflow_counter.hpp>
+
+namespace embed {
+boost::ut::suite overflow_counter_test = []() {
+  using namespace boost::ut;
+
+  "overflow_counter::update() increment by 1"_test = []() {
+    overflow_counter counter;
+
+    expect(that % 0 == counter.update(0));
+    expect(that % 1 == counter.update(1));
+    expect(that % 2 == counter.update(2));
+    expect(that % 3 == counter.update(3));
+    expect(that % 4 == counter.update(4));
+    expect(that % 5 == counter.update(5));
+    expect(that % 6 == counter.update(6));
+  };
+
+  // This is the case when a counter has been stopped. It shouldn't detect an
+  // overflow as the value hasn't overflowed it just has not moved.
+  "overflow_counter::update() increment by 0 expect no change"_test = []() {
+    overflow_counter counter;
+
+    expect(that % 10 == counter.update(10));
+    expect(that % 10 == counter.update(10));
+    expect(that % 10 == counter.update(10));
+    expect(that % 10 == counter.update(10));
+    expect(that % 10 == counter.update(10));
+    expect(that % 10 == counter.update(10));
+    expect(that % 10 == counter.update(10));
+  };
+
+  // This is the case when a counter has been stopped. It shouldn't detect an
+  // overflow as the value hasn't overflowed it just has not moved.
+  "overflow_counter::update() overflow w/ 32 bits"_test = []() {
+    overflow_counter counter;
+
+    expect(that % 0x0'0000'000A == counter.update(0xA));
+    expect(that % 0x1'0000'0000 == counter.update(0x0));
+    expect(that % 0x1'0000'000A == counter.update(0xA));
+
+    expect(that % 0x2'0000'0000 == counter.update(0x0));
+    expect(that % 0x2'0000'000A == counter.update(0xA));
+
+    expect(that % 0x3'0000'0000 == counter.update(0x0));
+    expect(that % 0x3'0000'000A == counter.update(0xA));
+
+    expect(that % 0x4'0000'0000 == counter.update(0x0));
+    expect(that % 0x4'0000'000A == counter.update(0xA));
+
+    expect(that % 0x5'0000'0000 == counter.update(0x0));
+    expect(that % 0x5'0000'000A == counter.update(0xA));
+    expect(that % 0x5'0000'000B == counter.update(0xB));
+    expect(that % 0x5'0000'000C == counter.update(0xC));
+    expect(that % 0x5'0000'000D == counter.update(0xD));
+    expect(that % 0x5'0000'000E == counter.update(0xE));
+    expect(that % 0x5'0000'000F == counter.update(0xF));
+    expect(that % 0x6'0000'0000 == counter.update(0x0));
+  };
+
+  "overflow_counter::update() overflow w/ 8 bits"_test = []() {
+    overflow_counter<8> counter;
+
+    expect(that % 0x00A == counter.update(0xA));
+    expect(that % 0x100 == counter.update(0x0));
+    expect(that % 0x10A == counter.update(0xA));
+
+    expect(that % 0x200 == counter.update(0x0));
+    expect(that % 0x20A == counter.update(0xA));
+
+    expect(that % 0x300 == counter.update(0x0));
+    expect(that % 0x30A == counter.update(0xA));
+
+    expect(that % 0x400 == counter.update(0x0));
+    expect(that % 0x40A == counter.update(0xA));
+
+    expect(that % 0x500 == counter.update(0x0));
+    expect(that % 0x50A == counter.update(0xA));
+    expect(that % 0x50B == counter.update(0xB));
+    expect(that % 0x50C == counter.update(0xC));
+    expect(that % 0x50D == counter.update(0xD));
+    expect(that % 0x50E == counter.update(0xE));
+    expect(that % 0x50F == counter.update(0xF));
+    expect(that % 0x600 == counter.update(0x0));
+  };
+
+  "overflow_counter::update() reset"_test = []() {
+    overflow_counter<8> counter;
+
+    expect(that % 0x00A == counter.update(0xA));
+    expect(that % 0x100 == counter.update(0x0));
+    expect(that % 0x10A == counter.update(0xA));
+
+    expect(that % 0x200 == counter.update(0x0));
+    expect(that % 0x20A == counter.update(0xA));
+
+    expect(that % 0x300 == counter.update(0x0));
+    expect(that % 0x30A == counter.update(0xA));
+
+    expect(that % 0x400 == counter.update(0x0));
+    expect(that % 0x40A == counter.update(0xA));
+
+    counter.reset();
+
+    expect(that % 0x00A == counter.update(0xA));
+  };
+};
+}  // namespace embed


### PR DESCRIPTION
Extend a counter's count from an arbitrary bit width to 64-bits by
detecting overflows in the count. Each detected overflow is added to an
overflow counter which is combined with the current count in order create a
count up to 64-bits in length.

Resolves #63