### PR TITLE
Make interfaces conform to C++ core guidelines

### DIFF
--- a/include/libembeddedhal/adc/adc.hpp
+++ b/include/libembeddedhal/adc/adc.hpp
@@ -15,6 +15,15 @@ namespace embed {
  */
 class adc : public driver<>
 {
+  /// default constructor
+  adc() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  adc(const adc& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  adc& operator=(const adc& p_other) = delete;
+  /// Destroy the object
+  virtual ~adc() = default;
+
   /**
    * @brief Read a sample from the analog to digital converter.
    *

--- a/include/libembeddedhal/can/can.hpp
+++ b/include/libembeddedhal/can/can.hpp
@@ -43,6 +43,15 @@ public:
     bool is_remote_request = false;
   };
 
+  /// default constructor
+  can() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  can(const can& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  can& operator=(const can& p_other) = delete;
+  /// Destroy the object
+  virtual ~can() = default;
+
   /**
    * @brief Send a can message over the can bus
    *

--- a/include/libembeddedhal/counter/counter.hpp
+++ b/include/libembeddedhal/counter/counter.hpp
@@ -16,32 +16,29 @@ namespace embed {
 class counter : public driver<>
 {
 public:
-  /**
-   * @brief Set of controls for a counter.
-   *
-   */
+  /// Set of controls for a counter.
   enum class controls
   {
-    /**
-     * @brief Control value to start the counter
-     *
-     */
+    /// Start the counter
     start,
-    /**
-     * @brief Control value to stop a counter
-     *
-     */
+    /// Stop a counter
     stop,
-    /**
-     * @brief Control value to reset a counter. The counter shall remain in a
-     * running or stopped state after this call. So an ongoing counter will
-     * continue to count but will have its counter reset to zero if this control
-     * is used. If a counter is stopped, then it shall be reset to zero, and
-     * stay stopped.
-     *
-     */
+    /// Control value to reset a counter. The counter shall remain in a
+    /// running or stopped state after this call. So an ongoing counter will
+    /// continue to count but will have its counter reset to zero if this
+    /// control is used. If a counter is stopped, then it shall be reset to
+    /// zero, and stay stopped.
     reset,
   };
+
+  /// default constructor
+  counter() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  counter(const counter& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  counter& operator=(const counter& p_other) = delete;
+  /// Destroy the object
+  virtual ~counter() = default;
 
   /**
    * @brief Determine if the counter is currently running

--- a/include/libembeddedhal/dac/dac.hpp
+++ b/include/libembeddedhal/dac/dac.hpp
@@ -16,6 +16,15 @@ namespace embed {
 class dac : public driver<>
 {
 public:
+  /// default constructor
+  dac() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  dac(const dac& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  dac& operator=(const dac& p_other) = delete;
+  /// Destroy the object
+  virtual ~dac() = default;
+
   /**
    * @brief Generate a voltage between a defined LOW and HIGH voltage.
    *

--- a/include/libembeddedhal/driver.hpp
+++ b/include/libembeddedhal/driver.hpp
@@ -47,6 +47,15 @@ template<class settings_t = no_settings>
 class driver
 {
 public:
+  /// default constructor
+  driver() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  driver(const driver& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  driver& operator=(const driver& p_other) = delete;
+  /// Destroy the object
+  virtual ~driver() = default;
+
   /**
    * @brief Initialize the driver, apply the setting as defined in the
    * settings_t structure and enable it. Calling this function after it has
@@ -61,6 +70,7 @@ public:
   boost::leaf::result<void> initialize()
   {
     auto on_error = embed::error::setup();
+
     EMBED_CHECK(driver_initialize());
 
     m_initialized_settings = m_settings;
@@ -113,6 +123,8 @@ protected:
    * @return false driver initialization failed
    */
   virtual boost::leaf::result<void> driver_initialize() = 0;
+
+private:
   /// Mutable settings
   settings_t m_settings{};
   /// Saved version of the settings at initialization

--- a/include/libembeddedhal/gpio/gpio.hpp
+++ b/include/libembeddedhal/gpio/gpio.hpp
@@ -14,78 +14,45 @@ namespace embed {
  */
 enum class pin_resistor
 {
-  /**
-   * @brief No pull up. This will cause the pin to float. This may be desirable
-   * if the pin has an external resistor attached or if the signal is sensitive
-   * to external devices like resistors.
-   *
-   */
+  /// No pull up. This will cause the pin to float. This may be desirable if the
+  /// pin has an external resistor attached or if the signal is sensitive to
+  /// external devices like resistors.
   none = 0,
-  /**
-   * @brief Pull the pin down to devices GND. This will ensure that the voltage
-   * read by the pin when there is no signal on the pin is LOW (or false).
-   *
-   */
+  /// Pull the pin down to devices GND. This will ensure that the voltage read
+  /// by the pin when there is no signal on the pin is LOW (or false).
   pull_down,
-  /**
-   * @brief See pull down explanation, but in this case the pin is pulled up to
-   * VCC, also called VDD on some systems.
-   *
-   */
+  /// See pull down explanation, but in this case the pin is pulled up to VCC,
+  /// also called VDD on some systems.
   pull_up,
 };
 
-/**
- * @brief Generic settings for input pins
- *
- */
+/// Generic settings for input pins
 struct input_pin_settings
 {
-  /**
-   * @brief pull resistor for an input pin
-   *
-   */
+  /// pull resistor for an input pin
   pin_resistor resistor = pin_resistor::pull_up;
 };
 
-/**
- * @brief Generic settings for output pins
- *
- */
+/// Generic settings for output pins
 struct output_pin_settings
 {
-  /**
-   * @brief Set the starting level of the output pin on initialization. HIGH
-   * voltage defined as true and LOW voltage defined as false.
-   *
-   */
+  /// Set the starting level of the output pin on initialization. HIGH voltage
+  /// defined as true and LOW voltage defined as false.
   bool starting_level = true;
-  /**
-   * @brief Starting level of the output pin. HIGH voltage defined as true and
-   * LOW voltage defined as false.
-   *
-   */
+  /// Starting level of the output pin. HIGH voltage defined as true and LOW
+  /// voltage defined as false.
   bool open_drain = false;
-  /**
-   * @brief Pull resistor for the pin. This generally only helpful when open
-   * drain is enabled.
-   *
-   */
+  /// Pull resistor for the pin. This generally only helpful when open
+  /// drain is enabled.
   pin_resistor resistor = pin_resistor::pull_up;
 };
 
-/**
- * @brief Generic settings for interrupt pins
- *
- */
+/// Generic settings for interrupt pins
 struct interrupt_pin_settings
 {
-  /**
-   * @brief pull resistor for an interrupt pin. Generally advised to NOT use
-   * `pin_resistor::none` and if it is used and external pull resistor should be
-   * placed on the pin to prevent random interrupt from firing.
-   *
-   */
+  /// pull resistor for an interrupt pin. Generally advised to NOT use
+  /// `pin_resistor::none` and if it is used and external pull resistor should
+  /// be placed on the pin to prevent random interrupt from firing.
   pin_resistor resistor = pin_resistor::pull_up;
 };
 
@@ -98,6 +65,15 @@ struct interrupt_pin_settings
 class input_pin : public driver<input_pin_settings>
 {
 public:
+  /// default constructor
+  input_pin() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  input_pin(const input_pin& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  input_pin& operator=(const input_pin& p_other) = delete;
+  /// Destroy the object
+  virtual ~input_pin() = default;
+
   /**
    * @brief Read the state of the input pin
    *
@@ -106,6 +82,7 @@ public:
    */
   virtual boost::leaf::result<bool> level() const = 0;
 };
+
 /**
  * @brief Digital output pin hardware abstraction.
  *
@@ -116,6 +93,15 @@ public:
 class output_pin : public driver<output_pin_settings>
 {
 public:
+  /// default constructor
+  output_pin() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  output_pin(const output_pin& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  output_pin& operator=(const output_pin& p_other) = delete;
+  /// Destroy the object
+  virtual ~output_pin() = default;
+
   /**
    * @brief Set the state of the pin
    *
@@ -135,6 +121,7 @@ public:
    */
   virtual boost::leaf::result<bool> level() const = 0;
 };
+
 /**
  * @brief Digital interrupt pin hardware abstraction.
  *
@@ -147,30 +134,28 @@ public:
 class interrupt_pin : public driver<interrupt_pin_settings>
 {
 public:
-  /**
-   * @brief The condition in which an interrupt is triggered.
-   *
-   */
+  /// The condition in which an interrupt is triggered.
   enum class trigger_edge
   {
-    /**
-     * @brief Trigger and interrupt when a pin transitions from HIGH voltage to
-     * LOW voltage.
-     *
-     */
+    /// Trigger and interrupt when a pin transitions from HIGH voltage to
+    /// LOW voltage.
     falling = 0,
-    /**
-     * @brief Trigger and interrupt when a pin transitions from LOW voltage to
-     * HIGH voltage.
-     *
-     */
+    /// Trigger and interrupt when a pin transitions from LOW voltage to
+    /// HIGH voltage.
     rising = 1,
-    /**
-     * @brief Trigger and interrupt when a pin transitions it state
-     *
-     */
+    /// Trigger and interrupt when a pin transitions it state
     both = 2,
   };
+
+  /// default constructor
+  interrupt_pin() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  interrupt_pin(const interrupt_pin& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  interrupt_pin& operator=(const interrupt_pin& p_other) = delete;
+  /// Destroy the object
+  virtual ~interrupt_pin() = default;
+
   /**
    * @brief Return the voltage level of the pin
    *

--- a/include/libembeddedhal/i2c/i2c.hpp
+++ b/include/libembeddedhal/i2c/i2c.hpp
@@ -77,6 +77,15 @@ public:
   struct bus_error
   {};
 
+  /// default constructor
+  i2c() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  i2c(const i2c& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  i2c& operator=(const i2c& p_other) = delete;
+  /// Destroy the object
+  virtual ~i2c() = default;
+
   /**
    * @brief perform an i2c transaction with another device on the bus. The type
    * of transaction depends on values of input parameters. This function will

--- a/include/libembeddedhal/pwm/pwm.hpp
+++ b/include/libembeddedhal/pwm/pwm.hpp
@@ -13,6 +13,15 @@ namespace embed {
  */
 class pwm : public driver<>
 {
+  /// default constructor
+  pwm() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  pwm(const pwm& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  pwm& operator=(const pwm& p_other) = delete;
+  /// Destroy the object
+  virtual ~pwm() = default;
+
   /**
    * @brief Set the operating frequency of the pwm channel. Note that on many
    * implementations, setting the frequency of a singular channel can have the

--- a/include/libembeddedhal/serial/serial.hpp
+++ b/include/libembeddedhal/serial/serial.hpp
@@ -143,6 +143,15 @@ public:
   struct invalid_settings
   {};
 
+  /// default constructor
+  serial() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  serial(const serial& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  serial& operator=(const serial& p_other) = delete;
+  /// Destroy the object
+  virtual ~serial() = default;
+
   /**
    * @brief Write data on the transmitter line of the port. This function will
    * block until the entire transfer is finished.

--- a/include/libembeddedhal/spi/spi.hpp
+++ b/include/libembeddedhal/spi/spi.hpp
@@ -30,6 +30,15 @@ struct spi_settings
 class spi : public driver<spi_settings>
 {
 public:
+  /// default constructor
+  spi() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  spi(const spi& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  spi& operator=(const spi& p_other) = delete;
+  /// Destroy the object
+  virtual ~spi() = default;
+
   /**
    * @brief Send and receieve data between a selected device on the spi bus.
    * This function will block until the entire transfer is finished.

--- a/include/libembeddedhal/timer/timer.hpp
+++ b/include/libembeddedhal/timer/timer.hpp
@@ -17,6 +17,15 @@ namespace embed {
 class timer : public driver<>
 {
 public:
+  /// default constructor
+  timer() = default;
+  /// Explicitly delete copy constructor to prevent slicing
+  timer(const timer& p_other) = delete;
+  /// Explicitly delete assignment operator to prevent slicing
+  timer& operator=(const timer& p_other) = delete;
+  /// Destroy the object
+  virtual ~timer() = default;
+
   /**
    * @brief Error type indicating that the desired time delay is not achievable
    * with this timer.
@@ -48,7 +57,6 @@ public:
     /// The maximum possible delay allowed.
     std::chrono::nanoseconds maximum;
   };
-
   /**
    * @brief Determine if the timer is currently running
    *
@@ -56,7 +64,6 @@ public:
    * @return boost::leaf::result<bool> - driver specific error, if any.
    */
   virtual boost::leaf::result<bool> is_running() = 0;
-
   /**
    * @brief Stops a scheduled event from happening.
    *
@@ -70,7 +77,6 @@ public:
    * @return boost::leaf::result<void> - driver specific error, if any.
    */
   virtual boost::leaf::result<void> clear() = 0;
-
   /**
    * @brief Schedule an callback to be called at a designated time/interval
    *

--- a/tests/driver.test.cpp
+++ b/tests/driver.test.cpp
@@ -34,7 +34,7 @@ public:
     return boost::leaf::new_error(dummy_error{});
   }
 
-  boost::leaf::result<void> driver_initialize()
+  boost::leaf::result<void> driver_initialize() override
   {
     auto on_error = embed::error::setup();
     return errorable_function();


### PR DESCRIPTION
- Add virtual destructors
- Delete copy constructor and assignment operator