### PR TITLE
Implement rule of 5 in all interfaces

### DIFF
--- a/include/libembeddedhal/adc/adc.hpp
+++ b/include/libembeddedhal/adc/adc.hpp
@@ -16,15 +16,6 @@ namespace embed {
 class adc : public driver<>
 {
 public:
-  /// default constructor
-  adc() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  adc(const adc& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  adc& operator=(const adc& p_other) = delete;
-  /// Destroy the object
-  virtual ~adc() = default;
-
   /**
    * @brief Read a sample from the analog to digital converter.
    *

--- a/include/libembeddedhal/can/can.hpp
+++ b/include/libembeddedhal/can/can.hpp
@@ -44,15 +44,6 @@ public:
     bool is_remote_request = false;
   };
 
-  /// default constructor
-  can() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  can(const can& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  can& operator=(const can& p_other) = delete;
-  /// Destroy the object
-  virtual ~can() = default;
-
   /**
    * @brief Send a can message over the can bus
    *

--- a/include/libembeddedhal/counter/counter.hpp
+++ b/include/libembeddedhal/counter/counter.hpp
@@ -37,15 +37,6 @@ public:
     reset,
   };
 
-  /// default constructor
-  counter() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  counter(const counter& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  counter& operator=(const counter& p_other) = delete;
-  /// Destroy the object
-  virtual ~counter() = default;
-
   /**
    * @brief Error type indicating that the desired time delay is not achievable
    * with this timer.

--- a/include/libembeddedhal/dac/dac.hpp
+++ b/include/libembeddedhal/dac/dac.hpp
@@ -16,15 +16,6 @@ namespace embed {
 class dac : public driver<>
 {
 public:
-  /// default constructor
-  dac() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  dac(const dac& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  dac& operator=(const dac& p_other) = delete;
-  /// Destroy the object
-  virtual ~dac() = default;
-
   /**
    * @brief Generate a voltage between a defined LOW and HIGH voltage.
    *

--- a/include/libembeddedhal/driver.hpp
+++ b/include/libembeddedhal/driver.hpp
@@ -53,6 +53,8 @@ public:
   driver(const driver& p_other) = delete;
   /// Explicitly delete assignment operator to prevent slicing
   driver& operator=(const driver& p_other) = delete;
+  /// Explicitly delete move constructor
+  driver(const driver&& p_other) = delete;
   /// Destroy the object
   virtual ~driver() = default;
 

--- a/include/libembeddedhal/gpio/gpio.hpp
+++ b/include/libembeddedhal/gpio/gpio.hpp
@@ -65,15 +65,6 @@ struct interrupt_pin_settings
 class input_pin : public driver<input_pin_settings>
 {
 public:
-  /// default constructor
-  input_pin() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  input_pin(const input_pin& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  input_pin& operator=(const input_pin& p_other) = delete;
-  /// Destroy the object
-  virtual ~input_pin() = default;
-
   /**
    * @brief Read the state of the input pin
    *
@@ -93,15 +84,6 @@ public:
 class output_pin : public driver<output_pin_settings>
 {
 public:
-  /// default constructor
-  output_pin() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  output_pin(const output_pin& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  output_pin& operator=(const output_pin& p_other) = delete;
-  /// Destroy the object
-  virtual ~output_pin() = default;
-
   /**
    * @brief Set the state of the pin
    *
@@ -146,16 +128,6 @@ public:
     /// Trigger and interrupt when a pin transitions it state
     both = 2,
   };
-
-  /// default constructor
-  interrupt_pin() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  interrupt_pin(const interrupt_pin& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  interrupt_pin& operator=(const interrupt_pin& p_other) = delete;
-  /// Destroy the object
-  virtual ~interrupt_pin() = default;
-
   /**
    * @brief Return the voltage level of the pin
    *

--- a/include/libembeddedhal/i2c/i2c.hpp
+++ b/include/libembeddedhal/i2c/i2c.hpp
@@ -76,16 +76,6 @@ public:
    */
   struct bus_error
   {};
-
-  /// default constructor
-  i2c() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  i2c(const i2c& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  i2c& operator=(const i2c& p_other) = delete;
-  /// Destroy the object
-  virtual ~i2c() = default;
-
   /**
    * @brief perform an i2c transaction with another device on the bus. The type
    * of transaction depends on values of input parameters. This function will

--- a/include/libembeddedhal/pwm/pwm.hpp
+++ b/include/libembeddedhal/pwm/pwm.hpp
@@ -20,15 +20,6 @@ struct pwm_settings
  */
 class pwm : public driver<pwm_settings>
 {
-  /// default constructor
-  pwm() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  pwm(const pwm& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  pwm& operator=(const pwm& p_other) = delete;
-  /// Destroy the object
-  virtual ~pwm() = default;
-
   /**
    * @brief Set the duty cycle percentage
    *

--- a/include/libembeddedhal/serial/serial.hpp
+++ b/include/libembeddedhal/serial/serial.hpp
@@ -142,16 +142,6 @@ public:
    */
   struct invalid_settings
   {};
-
-  /// default constructor
-  serial() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  serial(const serial& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  serial& operator=(const serial& p_other) = delete;
-  /// Destroy the object
-  virtual ~serial() = default;
-
   /**
    * @brief Write data on the transmitter line of the port. This function will
    * block until the entire transfer is finished.

--- a/include/libembeddedhal/spi/spi.hpp
+++ b/include/libembeddedhal/spi/spi.hpp
@@ -30,15 +30,6 @@ struct spi_settings
 class spi : public driver<spi_settings>
 {
 public:
-  /// default constructor
-  spi() = default;
-  /// Explicitly delete copy constructor to prevent slicing
-  spi(const spi& p_other) = delete;
-  /// Explicitly delete assignment operator to prevent slicing
-  spi& operator=(const spi& p_other) = delete;
-  /// Destroy the object
-  virtual ~spi() = default;
-
   /**
    * @brief Send and receieve data between a selected device on the spi bus.
    * This function will block until the entire transfer is finished.


### PR DESCRIPTION
Remove unnecessary rule of 5 definitions in interfaces.