### PR TITLE
Remove operator+/- from frequency class

### DIFF
--- a/include/libembeddedhal/frequency.hpp
+++ b/include/libembeddedhal/frequency.hpp
@@ -216,32 +216,6 @@ public:
   constexpr auto operator<=>(const frequency&) const noexcept = default;
 
   /**
-   * @brief sum two frequencies together
-   *
-   * @param p_lhs - left hand frequency
-   * @param p_rhs - right hand frequency
-   * @return constexpr frequency - sum of the two frequencies
-   */
-  constexpr friend frequency operator+(frequency p_lhs,
-                                       frequency p_rhs) noexcept
-  {
-    return frequency{ p_lhs.cycles_per_second() + p_rhs.cycles_per_second() };
-  }
-
-  /**
-   * @brief subtract two frequencies from each other
-   *
-   * @param p_lhs - left hand frequency
-   * @param p_rhs - right hand frequency
-   * @return constexpr frequency - difference of two frequencies
-   */
-  constexpr friend frequency operator-(frequency p_lhs,
-                                       frequency p_rhs) noexcept
-  {
-    return frequency{ p_lhs.cycles_per_second() - p_rhs.cycles_per_second() };
-  }
-
-  /**
    * @brief Scale up a frequency by an integer factor
    *
    * @tparam Integer - type of the integer

--- a/tests/frequency.test.cpp
+++ b/tests/frequency.test.cpp
@@ -94,17 +94,6 @@ boost::ut::suite frequency_duration_from_cycles = []() {
          (1'000'000_MHz).duration_from_cycles<frequency::int_t, std::pico>(1));
 };
 
-boost::ut::suite frequency_plus_minus_operator = []() {
-  using namespace boost::ut;
-  using namespace std::literals;
-  using namespace embed::literals;
-
-  expect(eq(1100_kHz, (1_MHz + 100_kHz)));
-  expect(eq(15'001_Hz, (15_kHz + 1_Hz)));
-  expect(eq(14'999_Hz, (15_kHz - 1_Hz)));
-  expect(eq(1'015_kHz, (15_kHz + 1_MHz)));
-};
-
 boost::ut::suite frequency_scalar_operator = []() {
   using namespace boost::ut;
   using namespace std::literals;


### PR DESCRIPTION
These operations don't really make physical sense and can lead to
negative frequencies which can result in calculation errors so these
operators have been removed.

Resolves #89