### PR TITLE
[[nodiscard]] everything reasonable

### DIFF
--- a/include/libembeddedhal/bit_limits.hpp
+++ b/include/libembeddedhal/bit_limits.hpp
@@ -12,7 +12,7 @@ namespace embed {
  * @return consteval uint32_t - mask with 1s at the LSB
  */
 template<size_t BitWidth, std::integral T>
-static consteval T generate_field_of_ones() noexcept
+[[nodiscard]] consteval T generate_field_of_ones() noexcept
 {
   T result = 0;
   for (size_t i = 0; i < BitWidth; i++) {
@@ -47,7 +47,7 @@ struct bit_limits
    *
    * @return constexpr int_t maximum value
    */
-  static constexpr int_t max() noexcept
+  [[nodiscard]] static constexpr int_t max() noexcept
   {
     if constexpr (std::is_signed_v<int_t>) {
       int_t max = generate_field_of_ones<BitWidth, int_t>();
@@ -68,7 +68,7 @@ struct bit_limits
    *
    * @return constexpr int_t minimum value
    */
-  static constexpr int_t min() noexcept
+  [[nodiscard]] static constexpr int_t min() noexcept
   {
     if constexpr (BitWidth == 64) {
       return std::numeric_limits<int_t>::min();

--- a/include/libembeddedhal/can/network.hpp
+++ b/include/libembeddedhal/can/network.hpp
@@ -80,7 +80,7 @@ public:
      *
      * @return can::message_t
      */
-    can::message_t secure_get() noexcept
+    [[nodiscard]] can::message_t secure_get() noexcept
     {
       // Continuously check if the received CAN message is valid. NOTE: that, in
       // general, the looping logic for this function almost never occurs as
@@ -207,7 +207,7 @@ public:
    *
    * @return can& reference to the can peripheral driver
    */
-  can& bus() noexcept { return *m_can; }
+  [[nodiscard]] can& bus() noexcept { return *m_can; }
 
   /**
    * @brief Get the Internal Map object
@@ -217,7 +217,7 @@ public:
    *
    * @return const auto& map of all of the messages in the network.
    */
-  const auto& get_internal_map() noexcept { return m_messages; }
+  [[nodiscard]] const auto& get_internal_map() noexcept { return m_messages; }
 
 private:
   void receive_handler(const can::message_t& p_message) noexcept

--- a/include/libembeddedhal/config.hpp
+++ b/include/libembeddedhal/config.hpp
@@ -35,7 +35,7 @@ namespace embed {
  * @return true - matches the platform string
  * @return false - does not matches the platform string
  */
-constexpr bool is_platform(std::string_view p_platform) noexcept
+[[nodiscard]] constexpr bool is_platform(std::string_view p_platform) noexcept
 {
   return config::platform.starts_with(p_platform);
 }
@@ -46,7 +46,7 @@ constexpr bool is_platform(std::string_view p_platform) noexcept
  * @return true - this application is a test
  * @return false - this application is not a test
  */
-constexpr bool is_a_test() noexcept
+[[nodiscard]] constexpr bool is_a_test() noexcept
 {
   return (config::platform.starts_with("unit_test") ||
           config::platform.starts_with("unittest") ||

--- a/include/libembeddedhal/counter/counter.hpp
+++ b/include/libembeddedhal/counter/counter.hpp
@@ -38,7 +38,7 @@ public:
    * @return boost::leaf::result<void> - any error that occurred during this
    * operation.
    */
-  virtual boost::leaf::result<void> control(controls p_control)
+  [[nodiscard]] virtual boost::leaf::result<void> control(controls p_control)
   {
     return driver_control(p_control);
   }
@@ -50,7 +50,7 @@ public:
    *
    * @return bool - true if the counter is currently running.
    */
-  virtual bool is_running() { return driver_is_running(); }
+  [[nodiscard]] virtual bool is_running() { return driver_is_running(); }
   /**
    * @brief Get the uptime of the counter since it has started.
    *
@@ -67,7 +67,7 @@ public:
    * @return std::chrono::nanoseconds - the current uptime since the counter has
    * started.
    */
-  std::chrono::nanoseconds uptime() { return driver_uptime(); }
+  [[nodiscard]] std::chrono::nanoseconds uptime() { return driver_uptime(); }
 
 private:
   virtual boost::leaf::result<void> driver_control(controls p_control) = 0;

--- a/include/libembeddedhal/counter/counter_utility.hpp
+++ b/include/libembeddedhal/counter/counter_utility.hpp
@@ -11,7 +11,7 @@ namespace embed {
  * @return boost::leaf::result<void> - any errors that occurred when attempting
  * to reset counter.
  */
-inline boost::leaf::result<void> reset(counter& p_counter)
+[[nodiscard]] inline boost::leaf::result<void> reset(counter& p_counter)
 {
   return p_counter.control(counter::controls::reset);
 }
@@ -22,7 +22,7 @@ inline boost::leaf::result<void> reset(counter& p_counter)
  * @return boost::leaf::result<void> - any errors that occurred when attempting
  * to start counter.
  */
-inline boost::leaf::result<void> start(counter& p_counter)
+[[nodiscard]] inline boost::leaf::result<void> start(counter& p_counter)
 {
   return p_counter.control(counter::controls::start);
 }
@@ -33,7 +33,7 @@ inline boost::leaf::result<void> start(counter& p_counter)
  * @return boost::leaf::result<void> - any errors that occurred when attempting
  * to stop counter.
  */
-inline boost::leaf::result<void> stop(counter& p_counter)
+[[nodiscard]] inline boost::leaf::result<void> stop(counter& p_counter)
 {
   return p_counter.control(counter::controls::stop);
 }

--- a/include/libembeddedhal/enum.hpp
+++ b/include/libembeddedhal/enum.hpp
@@ -19,7 +19,7 @@ concept enumeration = std::is_enum_v<T>;
  * @return constexpr auto - return the integral value of the enum with the same
  * type as the enumeration.
  */
-constexpr auto value(enumeration auto p_enum_value) noexcept
+[[nodiscard]] constexpr auto value(enumeration auto p_enum_value) noexcept
 {
   return static_cast<std::underlying_type_t<decltype(p_enum_value)>>(
     p_enum_value);

--- a/include/libembeddedhal/error.hpp
+++ b/include/libembeddedhal/error.hpp
@@ -87,7 +87,7 @@ public:
    * @return auto - return a const span with length equal to the number of
    * entries in the stacktrace list.
    */
-  auto get() const noexcept
+  [[nodiscard]] auto get() const noexcept
   {
     return std::span<const boost::leaf::e_source_location>(m_list.begin(),
                                                            m_count);
@@ -142,7 +142,9 @@ private:
  * @return auto - error handler for when an error is emitted on the calling
  * functions frame.
  */
-inline auto setup(
+[[nodiscard("Save this to a variable like so: \"auto on_error = "
+            "embed::error::setup();\"")]] inline auto
+setup(
   const char* p_function_name = std::source_location::current().function_name(),
   const char* p_file_name = std::source_location::current().file_name(),
   int p_line_number = std::source_location::current().line()) noexcept

--- a/include/libembeddedhal/frequency.hpp
+++ b/include/libembeddedhal/frequency.hpp
@@ -29,7 +29,8 @@ struct duty_cycle
    * @return constexpr auto - true if the duty cycles have the exact same
    * values.
    */
-  constexpr auto operator==(const duty_cycle& p_cycle) const noexcept
+  [[nodiscard]] constexpr auto operator==(
+    const duty_cycle& p_cycle) const noexcept
   {
     return (high == p_cycle.high) && (low == p_cycle.low);
   }
@@ -55,8 +56,9 @@ public:
    * @param p_precent - the target duty cycle percentage
    * @return constexpr duty_cycle - the duty cycle cycle counts
    */
-  static constexpr duty_cycle calculate_duty_cycle(int_t p_cycles,
-                                                   percent p_precent) noexcept
+  [[nodiscard]] static constexpr duty_cycle calculate_duty_cycle(
+    int_t p_cycles,
+    percent p_precent) noexcept
   {
     // Scale down value based on the integer percentage value in percent
     int_t high = p_cycles * p_precent;
@@ -83,7 +85,7 @@ public:
    *
    * @return constexpr auto - frequency value as an integer
    */
-  constexpr auto cycles_per_second() const noexcept
+  [[nodiscard]] constexpr auto cycles_per_second() const noexcept
   {
     return absolute_value(m_cycles_per_second);
   }
@@ -98,7 +100,7 @@ public:
    * the output frequency is greater than this frequency and there does not
    * exist an integer divider that can produce the output frequency.
    */
-  constexpr int_t divider(frequency p_target) const noexcept
+  [[nodiscard]] constexpr int_t divider(frequency p_target) const noexcept
   {
     if (p_target.m_cycles_per_second > cycles_per_second()) {
       return 0;
@@ -118,7 +120,7 @@ public:
    * duration.
    */
   template<typename Rep, typename Period>
-  constexpr int_t cycles_per(
+  [[nodiscard]] constexpr int_t cycles_per(
     std::chrono::duration<Rep, Period> p_duration) const noexcept
   {
     // Full Equation:
@@ -155,8 +157,8 @@ public:
    */
   template<typename Rep = std::chrono::nanoseconds::rep,
            typename Period = std::chrono::nanoseconds::period>
-  std::chrono::duration<Rep, Period> duration_from_cycles(
-    int_t p_cycles) const noexcept
+  [[nodiscard]] constexpr std::chrono::duration<Rep, Period>
+  duration_from_cycles(int_t p_cycles) const noexcept
   {
     // Full Equation (based on the equation in cycles_per()):
     // =========================================================================
@@ -185,7 +187,7 @@ public:
    * @return constexpr duty_cycle
    */
   template<typename Rep, typename Period>
-  constexpr duty_cycle calculate_duty_cycle(
+  [[nodiscard]] constexpr duty_cycle calculate_duty_cycle(
     std::chrono::duration<Rep, Period> p_duration,
     percent p_precent) const noexcept
   {
@@ -202,8 +204,9 @@ public:
    * @param p_precent - ratio of the duty cycle high time
    * @return constexpr duty_cycle
    */
-  constexpr duty_cycle calculate_duty_cycle(frequency p_target,
-                                            percent p_precent) const noexcept
+  [[nodiscard]] constexpr duty_cycle calculate_duty_cycle(
+    frequency p_target,
+    percent p_precent) const noexcept
   {
     return calculate_duty_cycle(divider(p_target), p_precent);
   }
@@ -213,7 +216,8 @@ public:
    *
    * @return auto - result of the comparison
    */
-  constexpr auto operator<=>(const frequency&) const noexcept = default;
+  [[nodiscard]] constexpr auto operator<=>(const frequency&) const noexcept =
+    default;
 
   /**
    * @brief Scale up a frequency by an integer factor
@@ -224,7 +228,8 @@ public:
    * @return constexpr frequency
    */
   template<std::integral Integer>
-  constexpr friend frequency operator*(frequency p_lhs, Integer p_rhs) noexcept
+  [[nodiscard]] constexpr friend frequency operator*(frequency p_lhs,
+                                                     Integer p_rhs) noexcept
   {
     return frequency{ p_lhs.cycles_per_second() * p_rhs };
   }
@@ -238,7 +243,8 @@ public:
    * @return constexpr frequency
    */
   template<std::integral Integer>
-  constexpr friend frequency operator*(Integer p_rhs, frequency p_lhs) noexcept
+  [[nodiscard]] constexpr friend frequency operator*(Integer p_rhs,
+                                                     frequency p_lhs) noexcept
   {
     return p_lhs * p_rhs;
   }
@@ -252,7 +258,8 @@ public:
    * @return constexpr frequency
    */
   template<std::integral Integer>
-  constexpr friend frequency operator/(frequency p_lhs, Integer p_rhs) noexcept
+  [[nodiscard]] constexpr friend frequency operator/(frequency p_lhs,
+                                                     Integer p_rhs) noexcept
   {
     return frequency{ rounding_division(p_lhs.cycles_per_second(),
                                         int_t{ p_rhs }) };
@@ -267,8 +274,8 @@ public:
    * @return constexpr int_t - frequency divider value representing the number
    * of cycles in the input that constitute one cycle in the target frequency.
    */
-  constexpr friend int_t operator/(frequency p_input,
-                                   frequency p_target) noexcept
+  [[nodiscard]] constexpr friend int_t operator/(frequency p_input,
+                                                 frequency p_target) noexcept
   {
     return p_input.divider(p_target);
   }
@@ -285,7 +292,7 @@ public:
    * duration.
    */
   template<typename Rep, typename Period>
-  constexpr friend int_t operator*(
+  [[nodiscard]] constexpr friend int_t operator*(
     frequency p_input,
     std::chrono::duration<Rep, Period> p_duration) noexcept
   {
@@ -304,7 +311,7 @@ public:
    * duration.
    */
   template<typename Rep, typename Period>
-  constexpr friend int_t operator*(
+  [[nodiscard]] constexpr friend int_t operator*(
     std::chrono::duration<Rep, Period> p_duration,
     frequency p_input) noexcept
   {
@@ -327,7 +334,8 @@ namespace literals {
  * @param p_value - frequency in hertz
  * @return consteval frequency - frequency in hertz
  */
-consteval frequency operator""_Hz(unsigned long long p_value) noexcept
+[[nodiscard]] consteval frequency operator""_Hz(
+  unsigned long long p_value) noexcept
 {
   return frequency{ static_cast<frequency::int_t>(p_value) };
 }
@@ -340,7 +348,8 @@ consteval frequency operator""_Hz(unsigned long long p_value) noexcept
  * @param p_value - frequency in kilohertz
  * @return consteval frequency - frequency in kilohertz
  */
-consteval frequency operator""_kHz(unsigned long long p_value) noexcept
+[[nodiscard]] consteval frequency operator""_kHz(
+  unsigned long long p_value) noexcept
 {
   const auto value = p_value * std::kilo::num;
   return frequency{ static_cast<frequency::int_t>(value) };
@@ -354,7 +363,8 @@ consteval frequency operator""_kHz(unsigned long long p_value) noexcept
  * @param p_value - frequency in megahertz
  * @return consteval frequency - frequency in megahertz
  */
-consteval frequency operator""_MHz(unsigned long long p_value) noexcept
+[[nodiscard]] consteval frequency operator""_MHz(
+  unsigned long long p_value) noexcept
 {
   const auto value = p_value * std::mega::num;
   return frequency{ static_cast<frequency::int_t>(value) };

--- a/include/libembeddedhal/i2c/i2c_util.hpp
+++ b/include/libembeddedhal/i2c/i2c_util.hpp
@@ -14,9 +14,8 @@ namespace embed {
  * @param p_data_out - buffer of bytes to write to the target device
  * @return boost::leaf::result<void> - any errors associated with the read call
  */
-inline boost::leaf::result<void> write(i2c& p_i2c,
-                                       std::byte p_address,
-                                       std::span<const std::byte> p_data_out)
+[[nodiscard]] inline boost::leaf::result<void>
+write(i2c& p_i2c, std::byte p_address, std::span<const std::byte> p_data_out)
 {
   return p_i2c.transaction(p_address, p_data_out, std::span<std::byte>{});
 }
@@ -30,9 +29,8 @@ inline boost::leaf::result<void> write(i2c& p_i2c,
  * @param p_data_in - buffer to read bytes into from target device
  * @return boost::leaf::result<void> - any errors associated with the read call
  */
-inline boost::leaf::result<void> read(i2c& p_i2c,
-                                      std::byte p_address,
-                                      std::span<std::byte> p_data_in)
+[[nodiscard]] inline boost::leaf::result<void>
+read(i2c& p_i2c, std::byte p_address, std::span<std::byte> p_data_in)
 {
   return p_i2c.transaction(p_address, std::span<std::byte>{}, p_data_in);
 }
@@ -48,9 +46,8 @@ inline boost::leaf::result<void> read(i2c& p_i2c,
  * bytes from target device or an error.
  */
 template<size_t BytesToRead>
-inline boost::leaf::result<std::array<std::byte, BytesToRead>> read(
-  i2c& p_i2c,
-  std::byte p_address)
+[[nodiscard]] inline boost::leaf::result<std::array<std::byte, BytesToRead>>
+read(i2c& p_i2c, std::byte p_address)
 {
   std::array<std::byte, BytesToRead> buffer;
   EMBED_CHECK(read(p_i2c, p_address, buffer));
@@ -69,7 +66,7 @@ inline boost::leaf::result<std::array<std::byte, BytesToRead>> read(
  *
  * @return boost::leaf::result<void> - any errors associated with the read call
  */
-inline boost::leaf::result<void> write_then_read(
+[[nodiscard]] inline boost::leaf::result<void> write_then_read(
   i2c& p_i2c,
   std::byte p_address,
   std::span<const std::byte> p_data_out,
@@ -90,10 +87,10 @@ inline boost::leaf::result<void> write_then_read(
  * @return boost::leaf::result<std::array<std::byte, BytesToRead>>
  */
 template<size_t BytesToRead>
-inline boost::leaf::result<std::array<std::byte, BytesToRead>> write_then_read(
-  i2c& p_i2c,
-  std::byte p_address,
-  std::span<const std::byte> p_data_out)
+[[nodiscard]] inline boost::leaf::result<std::array<std::byte, BytesToRead>>
+write_then_read(i2c& p_i2c,
+                std::byte p_address,
+                std::span<const std::byte> p_data_out)
 {
   std::array<std::byte, BytesToRead> buffer;
   EMBED_CHECK(write_then_read(p_i2c, p_address, p_data_out, buffer));

--- a/include/libembeddedhal/math.hpp
+++ b/include/libembeddedhal/math.hpp
@@ -12,7 +12,7 @@ namespace embed {
  * @param p_value - integer value to be made positive
  * @return constexpr auto - positive representation of the integer
  */
-constexpr auto absolute_value(std::integral auto p_value) noexcept
+[[nodiscard]] constexpr auto absolute_value(std::integral auto p_value) noexcept
 {
   if (p_value >= 0) {
     return p_value;
@@ -32,7 +32,8 @@ constexpr auto absolute_value(std::integral auto p_value) noexcept
  * Returns 0 if the denominator is greater than the numerator.
  */
 template<std::integral T>
-constexpr T rounding_division(T p_numerator, T p_denominator) noexcept
+[[nodiscard]] constexpr T rounding_division(T p_numerator,
+                                            T p_denominator) noexcept
 {
   bool num_sign = p_numerator > 0;
   bool den_sign = p_denominator > 0;

--- a/include/libembeddedhal/percent.hpp
+++ b/include/libembeddedhal/percent.hpp
@@ -54,7 +54,7 @@ namespace embed {
  * @return constexpr T - p_value but with resolution scaled up to type T
  */
 template<std::integral T, size_t SourceWidth, std::integral U>
-constexpr static T upscale_integer(U p_value) noexcept
+[[nodiscard]] constexpr T upscale_integer(U p_value) noexcept
 {
   constexpr size_t output_bit_width = sizeof(T) * CHAR_BIT;
 
@@ -116,7 +116,7 @@ public:
    *
    * @return constexpr overflow_t - maximum limit of int_t
    */
-  static constexpr overflow_t raw_max() noexcept
+  [[nodiscard]] static constexpr overflow_t raw_max() noexcept
   {
     return std::numeric_limits<int_t>::max();
   }
@@ -126,7 +126,7 @@ public:
    *
    * @return constexpr overflow_t - minimum limit of int_t
    */
-  static constexpr overflow_t raw_min() noexcept
+  [[nodiscard]] static constexpr overflow_t raw_min() noexcept
   {
     return std::numeric_limits<int_t>::min() + overflow_t{ 1 };
   }
@@ -136,7 +136,10 @@ public:
    *
    * @return constexpr overflow_t - 0 value for int_t
    */
-  static constexpr overflow_t raw_zero() noexcept { return int_t{ 0 }; }
+  [[nodiscard]] static constexpr overflow_t raw_zero() noexcept
+  {
+    return int_t{ 0 };
+  }
 
   /**
    * @brief Construct 0% percent object
@@ -191,7 +194,7 @@ public:
    * distance to the end of the bit width.
    */
   template<size_t BitWidth, std::integral T>
-  static constexpr percent convert(T p_value) noexcept
+  [[nodiscard]] static constexpr percent convert(T p_value) noexcept
   {
     const int_t up_scaled_value = upscale_integer<int_t, BitWidth, T>(p_value);
     return percent(up_scaled_value);
@@ -224,7 +227,8 @@ public:
    * @return constexpr percent
    */
   template<std::integral T>
-  static constexpr percent from_ratio(T p_progress, T p_maximum) noexcept
+  [[nodiscard]] static constexpr percent from_ratio(T p_progress,
+                                                    T p_maximum) noexcept
   {
     overflow_t result = p_progress;
     result = (result * raw_max()) / absolute_value(p_maximum);
@@ -238,7 +242,7 @@ public:
    *
    * @return T - percent value
    */
-  constexpr auto raw_value() const noexcept { return m_value; }
+  [[nodiscard]] constexpr auto raw_value() const noexcept { return m_value; }
 
   /**
    * @brief Convert percent to a floating point representation
@@ -248,7 +252,7 @@ public:
    * and 1.0f.
    */
   template<std::floating_point T>
-  constexpr T to() const noexcept
+  [[nodiscard]] constexpr T to() const noexcept
   {
     constexpr T maximum = static_cast<T>(raw_max());
     return static_cast<T>(m_value) / maximum;
@@ -260,7 +264,7 @@ public:
    * @return float - float representation of the precentage between 0.0f
    * and 1.0f.
    */
-  explicit operator float() const noexcept { return to<float>(); }
+  [[nodiscard]] explicit operator float() const noexcept { return to<float>(); }
 
   /**
    * @brief explicit cast to double.
@@ -268,7 +272,10 @@ public:
    * @return double - double representation of the precentage between 0.0
    * and 1.0
    */
-  explicit operator double() const noexcept { return to<double>(); }
+  [[nodiscard]] explicit operator double() const noexcept
+  {
+    return to<double>();
+  }
 
   /**
    * @brief Scale an integral value by a percent value.
@@ -284,7 +291,8 @@ public:
    * @return auto - the scaled down result of p_value * p_scale.
    */
   template<std::integral T>
-  friend constexpr auto operator*(T p_value, percent p_scale) noexcept
+  [[nodiscard]] friend constexpr auto operator*(T p_value,
+                                                percent p_scale) noexcept
   {
     overflow_t arith_container = p_value;
     arith_container = arith_container * p_scale.raw_value();
@@ -301,7 +309,8 @@ public:
    * @return constexpr auto - see other operator*
    */
   template<std::integral T>
-  friend constexpr auto operator*(percent p_scale, T p_value) noexcept
+  [[nodiscard]] friend constexpr auto operator*(percent p_scale,
+                                                T p_value) noexcept
   {
     return p_value * p_scale;
   }
@@ -327,7 +336,7 @@ public:
    *
    * @return auto - string representation of the percent.
    */
-  auto to_string() const noexcept
+  [[nodiscard]] auto to_string() const noexcept
   {
     constexpr int_t fixed_percent_scalar = 1000000000;
     // Based on the number of characters needed to hold "fixed_percent_scalar"

--- a/include/libembeddedhal/serial/serial_util.hpp
+++ b/include/libembeddedhal/serial/serial_util.hpp
@@ -10,7 +10,7 @@
 
 namespace embed {
 
-inline boost::leaf::result<void> wait(
+[[nodiscard]] inline boost::leaf::result<void> wait(
   serial& p_serial,
   size_t p_length,
   std::optional<std::chrono::nanoseconds> p_timeout = std::nullopt)
@@ -37,13 +37,14 @@ inline boost::leaf::result<void> wait(
   return {};
 }
 
-inline boost::leaf::result<void> write(serial& p_serial,
-                                       std::span<const std::byte> p_data_out)
+[[nodiscard]] inline boost::leaf::result<void> write(
+  serial& p_serial,
+  std::span<const std::byte> p_data_out)
 {
   return p_serial.write(p_data_out);
 }
 
-inline boost::leaf::result<std::span<const std::byte>> read(
+[[nodiscard]] inline boost::leaf::result<std::span<const std::byte>> read(
   serial& p_serial,
   std::span<std::byte> p_data_in,
   std::optional<std::chrono::nanoseconds> p_timeout = std::nullopt)
@@ -53,9 +54,9 @@ inline boost::leaf::result<std::span<const std::byte>> read(
 }
 
 template<size_t BytesToRead>
-inline boost::leaf::result<std::array<std::byte, BytesToRead>> read(
-  serial& p_serial,
-  std::optional<std::chrono::nanoseconds> p_timeout = std::nullopt)
+[[nodiscard]] inline boost::leaf::result<std::array<std::byte, BytesToRead>>
+read(serial& p_serial,
+     std::optional<std::chrono::nanoseconds> p_timeout = std::nullopt)
 {
   std::array<std::byte, BytesToRead> buffer;
   EMBED_CHECK(wait(p_serial, BytesToRead, p_timeout));
@@ -63,7 +64,7 @@ inline boost::leaf::result<std::array<std::byte, BytesToRead>> read(
   return buffer;
 }
 
-inline boost::leaf::result<void> write_then_read(
+[[nodiscard]] inline boost::leaf::result<void> write_then_read(
   serial& p_serial,
   std::span<const std::byte> p_data_out,
   std::span<std::byte> p_data_in,
@@ -75,7 +76,8 @@ inline boost::leaf::result<void> write_then_read(
 }
 
 template<size_t BytesToRead>
-inline boost::leaf::result<std::array<std::byte, BytesToRead>> write_then_read(
+[[nodiscard]] inline boost::leaf::result<std::array<std::byte, BytesToRead>>
+write_then_read(
   serial& p_serial,
   std::span<const std::byte> p_data_out,
   std::optional<std::chrono::nanoseconds> p_timeout = std::nullopt)

--- a/include/libembeddedhal/spi/spi.hpp
+++ b/include/libembeddedhal/spi/spi.hpp
@@ -57,9 +57,10 @@ public:
    * @return boost::leaf::result<void> - any error that occurred during this
    * operation.
    */
-  boost::leaf::result<void> transfer(std::span<const std::byte> p_data_out,
-                                     std::span<std::byte> p_data_in,
-                                     std::byte p_filler)
+  [[nodiscard]] boost::leaf::result<void> transfer(
+    std::span<const std::byte> p_data_out,
+    std::span<std::byte> p_data_in,
+    std::byte p_filler)
   {
     return driver_transfer(p_data_out, p_data_in, p_filler);
   }

--- a/include/libembeddedhal/spi/spi_util.hpp
+++ b/include/libembeddedhal/spi/spi_util.hpp
@@ -14,8 +14,9 @@ namespace embed {
  * @param p_data_out - data to be written to the SPI bus
  * @return boost::leaf::result<void> - any errors associated with this call
  */
-boost::leaf::result<void> write(spi& p_spi,
-                                std::span<const std::byte> p_data_out)
+[[nodiscard]] inline boost::leaf::result<void> write(
+  spi& p_spi,
+  std::span<const std::byte> p_data_out)
 {
   return p_spi.transfer(p_data_out, std::span<std::byte>{}, std::byte{ 0xFF });
 }
@@ -31,9 +32,10 @@ boost::leaf::result<void> write(spi& p_spi,
  * data.
  * @return boost::leaf::result<void> - any errors associated with this call
  */
-boost::leaf::result<void> read(spi& p_spi,
-                               std::span<std::byte> p_data_in,
-                               std::byte p_filler = std::byte{ 0xFF })
+[[nodiscard]] inline boost::leaf::result<void> read(
+  spi& p_spi,
+  std::span<std::byte> p_data_in,
+  std::byte p_filler = std::byte{ 0xFF })
 {
   return p_spi.transfer(std::span<std::byte>{}, p_data_in, p_filler);
 }
@@ -50,7 +52,7 @@ boost::leaf::result<void> read(spi& p_spi,
  * associated with this call
  */
 template<size_t BytesToRead>
-inline boost::leaf::result<std::array<std::byte, BytesToRead>> read(
+[[nodiscard]] boost::leaf::result<std::array<std::byte, BytesToRead>> read(
   spi& p_spi,
   std::byte p_filler = std::byte{ 0xFF })
 {
@@ -78,11 +80,11 @@ inline boost::leaf::result<std::array<std::byte, BytesToRead>> read(
  * begins.
  * @return boost::leaf::result<void>
  */
-boost::leaf::result<void> write_then_read(spi& p_spi,
-                                          std::span<const std::byte> p_data_out,
-                                          std::span<std::byte> p_data_in,
-                                          std::byte p_filler = std::byte{
-                                            0xFF })
+[[nodiscard]] inline boost::leaf::result<void> write_then_read(
+  spi& p_spi,
+  std::span<const std::byte> p_data_out,
+  std::span<std::byte> p_data_in,
+  std::byte p_filler = std::byte{ 0xFF })
 {
   EMBED_CHECK(write(p_spi, p_data_out));
   EMBED_CHECK(read(p_spi, p_data_in, p_filler));
@@ -102,10 +104,10 @@ boost::leaf::result<void> write_then_read(spi& p_spi,
  * @return boost::leaf::result<std::array<std::byte, BytesToRead>>
  */
 template<size_t BytesToRead>
-inline boost::leaf::result<std::array<std::byte, BytesToRead>> write_then_read(
-  spi& p_spi,
-  std::span<const std::byte> p_data_out,
-  std::byte p_filler = std::byte{ 0xFF })
+[[nodiscard]] boost::leaf::result<std::array<std::byte, BytesToRead>>
+write_then_read(spi& p_spi,
+                std::span<const std::byte> p_data_out,
+                std::byte p_filler = std::byte{ 0xFF })
 {
   EMBED_CHECK(write(p_spi, p_data_out));
   return read<BytesToRead>(p_spi, p_filler);

--- a/include/libembeddedhal/static_callable.hpp
+++ b/include/libembeddedhal/static_callable.hpp
@@ -50,7 +50,7 @@ public:
    *
    * @return auto* - static function's address
    */
-  auto* get_handler() noexcept { return &handler; }
+  [[nodiscard]] auto* get_handler() noexcept { return &handler; }
 
 private:
   /**

--- a/include/libembeddedhal/time.hpp
+++ b/include/libembeddedhal/time.hpp
@@ -64,12 +64,12 @@ public:
  *
  * @param p_delay - the amount of time to delay execution by
  */
-static auto sleep_for(time_period p_delay)
+inline void sleep_for(time_period p_delay)
 {
   if (global_clocks::m_global_sleep) {
-    return global_clocks::m_global_sleep(p_delay);
+    global_clocks::m_global_sleep(p_delay);
   } else {
-    return global_clocks::loop_sleep(p_delay);
+    global_clocks::loop_sleep(p_delay);
   }
 }
 /**
@@ -77,7 +77,7 @@ static auto sleep_for(time_period p_delay)
  *
  * @return auto - the global uptime
  */
-static auto uptime()
+[[nodiscard]] inline auto uptime()
 {
   if (global_clocks::m_global_uptime) {
     return global_clocks::m_global_uptime();
@@ -90,7 +90,7 @@ static auto uptime()
  *
  * @param p_sleep_function - the function to handle sleeping
  */
-static void set_global_sleep(sleep_function p_sleep_function) noexcept
+inline void set_global_sleep(sleep_function p_sleep_function) noexcept
 {
   global_clocks::m_global_sleep = p_sleep_function;
 }
@@ -99,7 +99,7 @@ static void set_global_sleep(sleep_function p_sleep_function) noexcept
  *
  * @param p_uptime_function - the function to return the current system uptime
  */
-static void set_global_uptime(uptime_function p_uptime_function) noexcept
+inline void set_global_uptime(uptime_function p_uptime_function) noexcept
 {
   global_clocks::m_global_uptime = p_uptime_function;
 }

--- a/include/libembeddedhal/to_array.hpp
+++ b/include/libembeddedhal/to_array.hpp
@@ -16,7 +16,8 @@ namespace embed {
  * @return constexpr std::array<char, N + 1> - the char array object
  */
 template<size_t N>
-constexpr std::array<char, N + 1> to_array(std::string_view p_view) noexcept
+[[nodiscard]] constexpr std::array<char, N + 1> to_array(
+  std::string_view p_view) noexcept
 {
   const size_t min = std::min(N, p_view.size());
   std::array<char, N + 1> result;

--- a/tests/counter/counter_utility.test.cpp
+++ b/tests/counter/counter_utility.test.cpp
@@ -5,7 +5,5 @@ namespace embed {
 boost::ut::suite counter_utility_test = []() {
   using namespace boost::ut;
   using namespace std::literals;
-  embed::this_thread::sleep_for(0ns);
-  embed::this_thread::uptime();
 };
 }  // namespace embed

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -3,17 +3,20 @@
 
 #include <libembeddedhal/time.hpp>
 
-void unit_test_sleep(std::chrono::nanoseconds p_sleep_time) {
+void unit_test_sleep(std::chrono::nanoseconds p_sleep_time)
+{
   std::this_thread::sleep_for(p_sleep_time);
 }
 
-std::chrono::nanoseconds unit_test_uptime() {
+std::chrono::nanoseconds unit_test_uptime()
+{
   return std::chrono::steady_clock::now().time_since_epoch();
 }
 
-int main() {
+int main()
+{
   embed::this_thread::set_global_sleep(unit_test_sleep);
   embed::this_thread::set_global_uptime(unit_test_uptime);
-  embed::this_thread::uptime();
+  [[maybe_unused]] auto value = embed::this_thread::uptime();
   embed::this_thread::sleep_for(std::chrono::nanoseconds(0));
 }


### PR DESCRIPTION
- Add nodiscard attribute to every function for which the result should
  not be discarded.
- Remove static from free functions and replaced with inline
- Add inline to free functions without it
- Remove inline from free functions that are templated
- Add constexpr to functions that can be constexpr

Resolves #82
Resolves #86 