### PR TITLE
Remove typdef int_t from frequency

### DIFF
--- a/include/libembeddedhal/frequency.hpp
+++ b/include/libembeddedhal/frequency.hpp
@@ -44,9 +44,6 @@ struct duty_cycle
 class frequency
 {
 public:
-  /// Integer type used throughout the class
-  using int_t = std::int64_t;
-
   /**
    * @brief Generate a duty_cycle object based on the percent value and
    * the input count value. The count value is split based on the ratio within
@@ -57,13 +54,13 @@ public:
    * @return constexpr duty_cycle - the duty cycle cycle counts
    */
   [[nodiscard]] static constexpr duty_cycle calculate_duty_cycle(
-    int_t p_cycles,
+    std::int64_t p_cycles,
     percent p_precent) noexcept
   {
     // Scale down value based on the integer percentage value in percent
-    int_t high = p_cycles * p_precent;
+    std::int64_t high = p_cycles * p_precent;
     // p_cycles will always be larger than or equal to high
-    int_t low = p_cycles - high;
+    std::int64_t low = p_cycles - high;
 
     return duty_cycle{
       .high = high,
@@ -76,7 +73,7 @@ public:
    *
    * @param p_value - frequency of the object
    */
-  explicit constexpr frequency(int_t p_value) noexcept
+  explicit constexpr frequency(std::int64_t p_value) noexcept
     : m_cycles_per_second(p_value)
   {}
 
@@ -95,12 +92,14 @@ public:
    * frequency provided.
    *
    * @param p_target - the target output frequency
-   * @return constexpr int_t - the divider, when applied to this frequency, will
-   * achieve the p_target frequency. A value of is an error and 0 indicates that
-   * the output frequency is greater than this frequency and there does not
-   * exist an integer divider that can produce the output frequency.
+   * @return constexpr std::int64_t - the divider, when applied to this
+   * frequency, will achieve the p_target frequency. A value of is an error and
+   * 0 indicates that the output frequency is greater than this frequency and
+   * there does not exist an integer divider that can produce the output
+   * frequency.
    */
-  [[nodiscard]] constexpr int_t divider(frequency p_target) const noexcept
+  [[nodiscard]] constexpr std::int64_t divider(
+    frequency p_target) const noexcept
   {
     if (p_target.m_cycles_per_second > cycles_per_second()) {
       return 0;
@@ -116,11 +115,11 @@ public:
    * @tparam Rep - type of the duration
    * @tparam Period - ratio of the time duration relative to 1 second
    * @param p_duration - the target time duration to get a cycle count from
-   * @return constexpr int_t - the number of cycles of this frequency within the
-   * duration.
+   * @return constexpr std::int64_t - the number of cycles of this frequency
+   * within the duration.
    */
   template<typename Rep, typename Period>
-  [[nodiscard]] constexpr int_t cycles_per(
+  [[nodiscard]] constexpr std::int64_t cycles_per(
     std::chrono::duration<Rep, Period> p_duration) const noexcept
   {
     // Full Equation:
@@ -142,7 +141,7 @@ public:
     // accuracy as possible.
     cycle_count = rounding_division((cycle_count * Period::num), Period::den);
 
-    return static_cast<int_t>(cycle_count);
+    return static_cast<std::int64_t>(cycle_count);
   }
 
   /**
@@ -158,7 +157,7 @@ public:
   template<typename Rep = std::chrono::nanoseconds::rep,
            typename Period = std::chrono::nanoseconds::period>
   [[nodiscard]] constexpr std::chrono::duration<Rep, Period>
-  duration_from_cycles(int_t p_cycles) const noexcept
+  duration_from_cycles(std::int64_t p_cycles) const noexcept
   {
     // Full Equation (based on the equation in cycles_per()):
     // =========================================================================
@@ -167,9 +166,9 @@ public:
     //   |period| =  | ---------------------------|
     //                \ frequency_hz * ratio_num /
     //
-    int_t numerator = p_cycles * Period::den;
-    int_t denominator = Period::num * m_cycles_per_second;
-    int_t duration = rounding_division(numerator, denominator);
+    std::int64_t numerator = p_cycles * Period::den;
+    std::int64_t denominator = Period::num * m_cycles_per_second;
+    std::int64_t duration = rounding_division(numerator, denominator);
 
     return std::chrono::duration<Rep, Period>(duration);
   }
@@ -262,7 +261,7 @@ public:
                                                      Integer p_rhs) noexcept
   {
     return frequency{ rounding_division(p_lhs.cycles_per_second(),
-                                        int_t{ p_rhs }) };
+                                        std::int64_t{ p_rhs }) };
   }
 
   /**
@@ -271,11 +270,13 @@ public:
    * @param p_input - the input frequency to be divided down to the target
    * frequency with an integer divider
    * @param p_target - the target frequency to reach via an integer divider
-   * @return constexpr int_t - frequency divider value representing the number
-   * of cycles in the input that constitute one cycle in the target frequency.
+   * @return constexpr std::int64_t - frequency divider value representing the
+   * number of cycles in the input that constitute one cycle in the target
+   * frequency.
    */
-  [[nodiscard]] constexpr friend int_t operator/(frequency p_input,
-                                                 frequency p_target) noexcept
+  [[nodiscard]] constexpr friend std::int64_t operator/(
+    frequency p_input,
+    frequency p_target) noexcept
   {
     return p_input.divider(p_target);
   }
@@ -288,11 +289,11 @@ public:
    * @tparam Period - ratio of the time duration relative to 1 second
    * @param p_input - the input frequency
    * @param p_duration - the target time duration to get a cycle count from
-   * @return constexpr int_t - the number of cycles of this frequency within the
-   * duration.
+   * @return constexpr std::int64_t - the number of cycles of this frequency
+   * within the duration.
    */
   template<typename Rep, typename Period>
-  [[nodiscard]] constexpr friend int_t operator*(
+  [[nodiscard]] constexpr friend std::int64_t operator*(
     frequency p_input,
     std::chrono::duration<Rep, Period> p_duration) noexcept
   {
@@ -307,11 +308,11 @@ public:
    * @tparam Period - ratio of the time duration relative to 1 second
    * @param p_input - the input frequency
    * @param p_duration - the target time duration to get a cycle count from
-   * @return constexpr int_t - the number of cycles of this frequency within the
-   * duration.
+   * @return constexpr std::int64_t - the number of cycles of this frequency
+   * within the duration.
    */
   template<typename Rep, typename Period>
-  [[nodiscard]] constexpr friend int_t operator*(
+  [[nodiscard]] constexpr friend std::int64_t operator*(
     std::chrono::duration<Rep, Period> p_duration,
     frequency p_input) noexcept
   {
@@ -319,7 +320,7 @@ public:
   }
 
 private:
-  int_t m_cycles_per_second = 1'000;
+  std::int64_t m_cycles_per_second = 1'000;
 };
 
 /// Default clock rate for serial communication protocols
@@ -337,7 +338,7 @@ namespace literals {
 [[nodiscard]] consteval frequency operator""_Hz(
   unsigned long long p_value) noexcept
 {
-  return frequency{ static_cast<frequency::int_t>(p_value) };
+  return frequency{ static_cast<std::int64_t>(p_value) };
 }
 
 /**
@@ -352,7 +353,7 @@ namespace literals {
   unsigned long long p_value) noexcept
 {
   const auto value = p_value * std::kilo::num;
-  return frequency{ static_cast<frequency::int_t>(value) };
+  return frequency{ static_cast<std::int64_t>(value) };
 }
 
 /**
@@ -367,7 +368,7 @@ namespace literals {
   unsigned long long p_value) noexcept
 {
   const auto value = p_value * std::mega::num;
-  return frequency{ static_cast<frequency::int_t>(value) };
+  return frequency{ static_cast<std::int64_t>(value) };
 }
 }  // namespace literals
 }  // namespace embed

--- a/tests/frequency.test.cpp
+++ b/tests/frequency.test.cpp
@@ -90,8 +90,8 @@ boost::ut::suite frequency_duration_from_cycles = []() {
   expect(10'250ms == (1_kHz).duration_from_cycles(10'250));
   expect(12'000'000ns == (1000_MHz).duration_from_cycles(12'000'000));
   expect(0ns == (1000_MHz).duration_from_cycles(0));
-  expect(std::chrono::duration<frequency::int_t, std::pico>(1) ==
-         (1'000'000_MHz).duration_from_cycles<frequency::int_t, std::pico>(1));
+  expect(std::chrono::duration<std::int64_t, std::pico>(1) ==
+         (1'000'000_MHz).duration_from_cycles<std::int64_t, std::pico>(1));
 };
 
 boost::ut::suite frequency_scalar_operator = []() {


### PR DESCRIPTION
Be explicit with the exact type that is used in frequency. Will prevent
confusion from users when it comes to the API of the code.

Resolves #88