### PR TITLE
can_network::register_message_id can return errors

### DIFF
--- a/include/libembeddedhal/can/network.hpp
+++ b/include/libembeddedhal/can/network.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <memory_resource>
 #include <unordered_map>
-#include <utility>
 
 #include "can.hpp"
 
@@ -184,7 +182,8 @@ public:
    * associated with the set ID.
    *
    */
-  [[nodiscard]] node_t* register_message_id(can::id_t p_id) noexcept
+  [[nodiscard]] boost::leaf::result<node_t*> register_message_id(
+    can::id_t p_id) noexcept
   {
     node_t empty_node;
 


### PR DESCRIPTION
Set return type of can_network::register_message_id to
boost::leaf::result<node*> so that this function can return errors if
needed in the future.

Issue #101