### PR TITLE
Fixup unit test requirements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: 📥 Install pip package 'clang' & 'pyyaml' (for ncc)
         shell: bash
-        run: python3 -m pip install clang pyyaml
+        run: python3 -m pip install clang==11.1 pyyaml
 
       # Because inputs.library is required for workflow_calls, if this value is
       # blank it means that the workflow was ran in libembeddedhal and not

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,5 +27,5 @@ class libembeddedhal_conan(ConanFile):
     def package_id(self):
         self.info.header_only()
 
-    def requirements(self):
-        self.requires("boost-ext-ut/1.1.8@")
+    def build_requirements(self):
+        self.test_requires("boost-ext-ut/1.1.8@")


### PR DESCRIPTION
Move boost-ext-ut from package requirements to test requirements so it
is only downloaded for testing the package.