### PR TITLE
Add uptime counter class

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -3,6 +3,7 @@
     "language": "en",
     "words": [
         "femto",
+        "pico",
         "microcontrollers",
         "libembeddedhal"
     ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(${TEST_NAME} tests/can/can.test.cpp
   tests/dac/dac.test.cpp
   tests/counter/counter.test.cpp
   tests/counter/counter_utility.test.cpp
+  tests/counter/uptime_counter.test.cpp
   tests/overflow_counter.test.cpp
   tests/gpio/gpio.test.cpp
   tests/static_memory_resource.test.cpp

--- a/include/libembeddedhal/counter/counter.hpp
+++ b/include/libembeddedhal/counter/counter.hpp
@@ -17,46 +17,33 @@ namespace embed {
 class counter
 {
 public:
-  /// Set of controls for a counter.
-  enum class controls
+  /**
+   * @brief Enumerations listing out the potential errors a counter could
+   * encounter
+   *
+   */
+  enum class errors
   {
-    /// Start the counter
-    start,
-    /// Stop a counter
-    stop,
-    /// Control value to reset a counter. The counter shall remain in a
-    /// running or stopped state after this call. So an ongoing counter will
-    /// continue to count but will have its counter reset to zero if this
-    /// control is used. If a counter is stopped, then it shall be reset to
-    /// zero, and stay stopped.
-    reset,
+    /// The counter has back tracked and a previous value is greater than the
+    /// current value. This is an invalid state for a hardware counter and
+    /// considered an error.
+    backtrack,
   };
+
   /**
-   * @brief Control the state of the counter
+   * @brief Returns the operating frequency of the counter.
    *
-   * @param p_control - new state for the counter
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation.
+   * @return boost::leaf::result<embed::frequency> - the operating frequency of
+   * the counter.
    */
-  [[nodiscard]] virtual boost::leaf::result<void> control(
-    controls p_control) noexcept
+  [[nodiscard]] boost::leaf::result<embed::frequency> frequency() noexcept
   {
-    return driver_control(p_control);
-  }
-  /**
-   * @brief Determine if the counter is currently running.
-   *
-   * If attempting to check if the counter is running results in an error,
-   * then treat that as if the counter is not active and return false.
-   *
-   * @return bool - true if the counter is currently running.
-   */
-  [[nodiscard]] virtual bool is_running() noexcept
-  {
-    return driver_is_running();
+    return driver_frequency();
   }
   /**
    * @brief Get the uptime of the counter since it has started.
+   *
+   * The count for a counter must always count up.
    *
    * Most counters are only support 32-bits or lower. In this case there are
    * multiple way to increase the bit width of the counter:
@@ -71,15 +58,13 @@ public:
    * @return std::chrono::nanoseconds - the current uptime since the counter has
    * started.
    */
-  [[nodiscard]] std::chrono::nanoseconds uptime() noexcept
+  [[nodiscard]] boost::leaf::result<std::uint64_t> uptime() noexcept
   {
     return driver_uptime();
   }
 
 private:
-  virtual boost::leaf::result<void> driver_control(
-    controls p_control) noexcept = 0;
-  virtual bool driver_is_running() noexcept = 0;
-  virtual std::chrono::nanoseconds driver_uptime() noexcept = 0;
+  virtual boost::leaf::result<std::uint64_t> driver_uptime() noexcept = 0;
+  virtual boost::leaf::result<embed::frequency> driver_frequency() noexcept = 0;
 };
 }  // namespace embed

--- a/include/libembeddedhal/counter/uptime_counter.hpp
+++ b/include/libembeddedhal/counter/uptime_counter.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "counter.hpp"
+
+namespace embed {
+/**
+ * @brief uptime counter takes a hardware counter and calculates the uptime in
+ * nanoseconds.
+ *
+ * This class should be used over calling frequency::duration_from_cycles() to
+ * calculate uptime because that function will overflow when 9223372 seconds or
+ * around 15 weeks have elapsed. This has to do with how the integer arithmetic
+ * is handled for converting from frequency to duration using a cycle count.
+ *
+ * So long as this class's uptime() is called within a 15 week timespan, the
+ * uptime will be accurate up to ~292 years.
+ */
+class uptime_counter
+{
+public:
+  /**
+   * @brief Construct a new uptime counter object
+   *
+   * @param p_counter - hardware counter
+   */
+  uptime_counter(counter& p_counter)
+    : m_counter(&p_counter)
+  {}
+
+  /**
+   * @brief Calculates the number of nanoseconds since the counter has started
+   *
+   * To get the correct uptime, this function must be called within a 15
+   * week time period to hold accuracy.
+   *
+   * @return boost::leaf::result<std::chrono::nanoseconds> - returns the
+   */
+  boost::leaf::result<std::chrono::nanoseconds> uptime()
+  {
+    using rep = std::chrono::nanoseconds::rep;
+    using period = std::chrono::nanoseconds::period;
+    auto frequency = BOOST_LEAF_CHECK(m_counter->frequency());
+    auto new_uptime = BOOST_LEAF_CHECK(m_counter->uptime());
+    if (new_uptime < m_previous_count) {
+      return boost::leaf::new_error(counter::errors::backtrack);
+    }
+    auto time_delta = new_uptime - m_previous_count;
+    auto nanosecond_delta =
+      frequency.duration_from_cycles<rep, period>(time_delta);
+    m_last_uptime += nanosecond_delta;
+    m_previous_count = new_uptime;
+    return m_last_uptime;
+  }
+
+private:
+  counter* m_counter = nullptr;
+  uint64_t m_previous_count{};
+  std::chrono::nanoseconds m_last_uptime{};
+};
+}  // namespace embed

--- a/include/libembeddedhal/percent.hpp
+++ b/include/libembeddedhal/percent.hpp
@@ -64,15 +64,15 @@ template<std::integral T, size_t SourceWidth, std::integral U>
 
   static_assert(SourceWidth >= 2, "Bit Width must be greater than ");
 
-  // Calculate the difference between the destination and the source width
-  constexpr size_t width_difference = output_bit_width - SourceWidth;
-
   constexpr size_t final_source_width =
-    (std::is_signed_v<T>) ? SourceWidth - 1 : SourceWidth;
+    (std::is_signed_v<U>) ? SourceWidth - 1 : SourceWidth;
   constexpr size_t final_width =
     (std::is_signed_v<T>) ? output_bit_width - 1 : output_bit_width;
 
-  T result = static_cast<T>(p_value) << width_difference;
+  // Calculate the difference between the destination and the source width
+  constexpr size_t width_difference = final_width - final_source_width;
+
+  T result = static_cast<T>(p_value << width_difference);
 
   if (p_value > 0) {
     for (size_t i = final_source_width; i < final_width;

--- a/tests/counter/uptime_counter.test.cpp
+++ b/tests/counter/uptime_counter.test.cpp
@@ -1,0 +1,162 @@
+#include <boost/ut.hpp>
+#include <libembeddedhal/counter/uptime_counter.hpp>
+#include <queue>
+
+namespace embed {
+
+boost::ut::suite uptime_utility_test = []() {
+  using namespace boost::ut;
+  using namespace std::literals;
+  using namespace embed::literals;
+
+  class mock_counter : public embed::counter
+  {
+  public:
+    boost::leaf::result<embed::frequency> driver_frequency() noexcept override
+    {
+      return m_frequency;
+    };
+
+    boost::leaf::result<std::uint64_t> driver_uptime() noexcept override
+    {
+      auto count = uptime_sequence.front();
+      uptime_sequence.pop();
+      return count;
+    };
+
+    std::queue<std::uint64_t> uptime_sequence{};
+
+  private:
+    embed::frequency m_frequency{ 1'000_MHz };
+  };
+
+  "[uptime_counter] zero"_test = []() {
+    // Setup
+    mock_counter mock;
+    uptime_counter uptime(mock);
+    mock.uptime_sequence.push(0);
+    mock.uptime_sequence.push(0);
+    mock.uptime_sequence.push(0);
+    mock.uptime_sequence.push(0);
+
+    // Exercise
+    auto nanoseconds0 = uptime.uptime().value();
+    auto nanoseconds1 = uptime.uptime().value();
+    auto nanoseconds2 = uptime.uptime().value();
+    auto nanoseconds3 = uptime.uptime().value();
+
+    // Verify
+    expect(that % (0ns).count() == nanoseconds0.count());
+    expect(that % (0ns).count() == nanoseconds1.count());
+    expect(that % (0ns).count() == nanoseconds2.count());
+    expect(that % (0ns).count() == nanoseconds3.count());
+  };
+
+  "[uptime_counter] one"_test = []() {
+    // Setup
+    mock_counter mock;
+    uptime_counter uptime(mock);
+    mock.uptime_sequence.push(1);
+    mock.uptime_sequence.push(2);
+    mock.uptime_sequence.push(3);
+    mock.uptime_sequence.push(4);
+
+    // Exercise
+    auto nanoseconds0 = uptime.uptime().value();
+    auto nanoseconds1 = uptime.uptime().value();
+    auto nanoseconds2 = uptime.uptime().value();
+    auto nanoseconds3 = uptime.uptime().value();
+
+    // Verify
+    expect(that % (1ns).count() == nanoseconds0.count());
+    expect(that % (2ns).count() == nanoseconds1.count());
+    expect(that % (3ns).count() == nanoseconds2.count());
+    expect(that % (4ns).count() == nanoseconds3.count());
+  };
+
+  "[uptime_counter] many"_test = []() {
+    // Setup
+    mock_counter mock;
+    uptime_counter uptime(mock);
+    mock.uptime_sequence.push(1);
+    mock.uptime_sequence.push(20);
+    mock.uptime_sequence.push(300);
+    mock.uptime_sequence.push(4000);
+    mock.uptime_sequence.push(50000);
+    mock.uptime_sequence.push(600000);
+    mock.uptime_sequence.push(7000000);
+    mock.uptime_sequence.push(7000001);
+    mock.uptime_sequence.push(7000001);
+    mock.uptime_sequence.push(7000005);
+
+    // Exercise
+    auto nanoseconds0 = uptime.uptime().value();
+    auto nanoseconds1 = uptime.uptime().value();
+    auto nanoseconds2 = uptime.uptime().value();
+    auto nanoseconds3 = uptime.uptime().value();
+    auto nanoseconds4 = uptime.uptime().value();
+    auto nanoseconds5 = uptime.uptime().value();
+    auto nanoseconds6 = uptime.uptime().value();
+    auto nanoseconds7 = uptime.uptime().value();
+    auto nanoseconds8 = uptime.uptime().value();
+    auto nanoseconds9 = uptime.uptime().value();
+
+    // Verify
+    expect(that % (1ns).count() == nanoseconds0.count());
+    expect(that % (20ns).count() == nanoseconds1.count());
+    expect(that % (300ns).count() == nanoseconds2.count());
+    expect(that % (4000ns).count() == nanoseconds3.count());
+    expect(that % (50000ns).count() == nanoseconds4.count());
+    expect(that % (600000ns).count() == nanoseconds5.count());
+    expect(that % (7000000ns).count() == nanoseconds6.count());
+    expect(that % (7000001ns).count() == nanoseconds7.count());
+    expect(that % (7000001ns).count() == nanoseconds8.count());
+    expect(that % (7000005ns).count() == nanoseconds9.count());
+  };
+
+  "[uptime_counter] boundaries"_test = []() {
+    // Setup
+    mock_counter mock;
+    uptime_counter uptime(mock);
+    // 9223372 seconds is the approximate limit for frequency to duration
+    // calculations so we will push that up to ns and see what happens.
+    mock.uptime_sequence.push(1);
+    mock.uptime_sequence.push(9223372 * std::nano::den);
+    mock.uptime_sequence.push((9223372 * std::nano::den) + 1);
+    mock.uptime_sequence.push((9223372 * std::nano::den) * 2);
+
+    // Exercise
+    auto nanoseconds0 = uptime.uptime().value();
+    auto nanoseconds1 = uptime.uptime().value();
+    auto nanoseconds2 = uptime.uptime().value();
+    auto nanoseconds3 = uptime.uptime().value();
+
+    // Verify
+    expect(that % (1ns).count() == nanoseconds0.count());
+    expect(that % (9223372000000000ns).count() == nanoseconds1.count());
+    expect(that % (9223372000000001ns).count() == nanoseconds2.count());
+    expect(that % (9223372000000000ns * 2).count() == nanoseconds3.count());
+  };
+
+  "[uptime_counter] errors"_test = []() {
+    // Setup
+    mock_counter mock;
+    uptime_counter uptime(mock);
+    mock.uptime_sequence.push(20);
+    mock.uptime_sequence.push(19);
+
+    // Exercise
+    boost::leaf::try_handle_all(
+      [&uptime]() -> boost::leaf::result<void> {
+        auto nanoseconds0 = uptime.uptime().value();
+        // Error should occur here!
+        auto nanoseconds1 = BOOST_LEAF_CHECK(uptime.uptime());
+        return {};
+      },
+      [](counter::errors p_error) {
+        expect(p_error == counter::errors::backtrack);
+      },
+      []() { expect(false) << "Backtrack error was not emitted"; });
+  };
+};
+}  // namespace embed

--- a/tests/frequency.test.cpp
+++ b/tests/frequency.test.cpp
@@ -86,7 +86,7 @@ boost::ut::suite frequency_user_defined_literals_test = []() {
 
   "frequency duration from cycles"_test = []() {
     expect(that % 1400us == (1_MHz).duration_from_cycles(1400));
-    expect(that % 2380929ns == (14_MHz).duration_from_cycles(33333));
+    expect(that % 2380943ns == (14_MHz).duration_from_cycles(33333));
     expect(that % 10'250ms == (1_kHz).duration_from_cycles(10'250));
     expect(that % 12'000'000ns == (1000_MHz).duration_from_cycles(12'000'000));
     expect(that % 0ns == (1000_MHz).duration_from_cycles(0));


### PR DESCRIPTION
uptime counter class is a solution to the uptime calculation problem
that counter and frequency have. The issue has to do with frequency's
duration_from_cyles() function. It takes a 64-bit number and performs
multiplication against a 32-bit number. The resultant for such a number
would need to be 96 bits in width. Once the input count reaches
a specific size, the result can no longer fit within a 64-bit number,
the result is invalid. The resulting std::chrono::nanoseconds object's
count() value, will still be far away from the 64-bit maximum.

To solve this, uptime counter does not take the whole uptime but
calculates the delta between the previous time uptime was called and the
current time. Then uses the count delta to calculate the nanoseconds
delta between uptime calls and adds that to a sum of nanoseconds since
the start of counting. This class will work so long as the delta
between uptime calls does not exceed a specific time duration.
This comes out to be 15 weeks.