### PR TITLE
Remove CXX extension from cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ project(libembeddedhal VERSION 0.0.1 LANGUAGES CXX)
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE include)
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_20)
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}


### PR DESCRIPTION
Was causing configure errors on different systems such as:

```
INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "CXX_EXTENSIONS" is not allowed.
```