### PR TITLE
Update sensors for high bandwidth

### DIFF
--- a/include/libembeddedhal/accelerometer/accelerometer2.hpp
+++ b/include/libembeddedhal/accelerometer/accelerometer2.hpp
@@ -74,31 +74,8 @@ public:
       default;
   };
 
-  /**
-   * @brief Read the current acceleration from the accelerometer.
-   *
-   * @return boost::leaf::result<sample> - a sample of data or an error
-   */
+  size_t samples_available();
 
-  /**
-   * @brief Read out acceleration data from the accelerometer.
-   *
-   * For accelerometers not configured to store data within a FIFO or do not
-   * have a FIFO available, this function will always return a span of data
-   * length 1 sample. For multiple samples multiple calls of this function will
-   * need to be made. This is the low bandwidth situation.
-   *
-   * If an accelerometer is configured to use a FIFO and utilizes interrupts to
-   * detect when the FIFO is almost/entirely full, then a circular buffer shall
-   * be used to store this data until read by this function. The length of the
-   * returned span will be minimum between the p_samples buffer or the circular
-   * buffer.
-   *
-   * @param p_samples - a buffer to fill with sample data
-   * @return boost::leaf::result<std::span<sample>> - an error or a span of
-   * sample data with the address equal to the p_samples argument and size, the
-   * number of samples filled into the buffer.
-   */
   [[nodiscard]] boost::leaf::result<std::span<sample>> read(
     std::span<sample> p_samples) noexcept
   {

--- a/include/libembeddedhal/accelerometer/accelerometer_util.hpp
+++ b/include/libembeddedhal/accelerometer/accelerometer_util.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <array>
+
+#include "accelerometer.hpp"
+
+namespace embed {
+/**
+ * @brief [WIP] Read N number of samples from the accelerometer.
+ *
+ * This function will block until all samples have been read into the buffer.
+ *
+ * @tparam SampleSize - number of samples to read from the device
+ * @param p_accelerometer - accelerometer implementation
+ * @return boost::leaf::result<
+ * std::array<accelerometer::sample, SampleSize>> - array of accelerometer
+ * samples or an error.
+ */
+template<size_t SampleSize = 1>
+[[nodiscard]] inline boost::leaf::result<
+  std::array<accelerometer::sample, SampleSize>>
+read(accelerometer& p_accelerometer)
+{
+  std::array<accelerometer::sample, SampleSize> samples;
+  BOOST_LEAF_CHECK(p_accelerometer.read(samples));
+  return samples;
+}
+}  // namespace embed

--- a/include/libembeddedhal/temperature/temperature.hpp
+++ b/include/libembeddedhal/temperature/temperature.hpp
@@ -19,12 +19,22 @@ public:
    * @return boost::leaf::result<nanokelvin> - current temperature reading or an
    * error.
    */
-  [[nodiscard]] boost::leaf::result<temperature> read() noexcept
+
+  /**
+   * @brief Read the current temperature from the sensor.
+   *
+   * @param p_sample -
+   * @return boost::leaf::result<std::span<temperature>> - a span with length
+   * based on the number of
+   */
+  [[nodiscard]] boost::leaf::result<std::span<temperature>> read(
+    std::span<temperature> p_sample) noexcept
   {
-    return driver_read();
+    return driver_read(p_sample);
   }
 
 private:
-  virtual boost::leaf::result<temperature> driver_read() noexcept = 0;
+  virtual boost::leaf::result<std::span<temperature>> driver_read(
+    std::span<temperature> p_sample) noexcept = 0;
 };
 }  // namespace embed

--- a/include/libembeddedhal/temperature/temperature_util.hpp
+++ b/include/libembeddedhal/temperature/temperature_util.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <array>
+
+#include "temperature.hpp"
+
+namespace embed {
+/**
+ * @brief Read N number of samples from the temperature sensor.
+ *
+ * This function will block until all samples have been read into the buffer.
+ *
+ * @tparam SampleSize - number of samples to read from the device
+ * @param p_temperature_sensor - temperature sensor implementation
+ * @return boost::leaf::result<std::array<temperature, SampleSize>> - array of
+ * temperature data or an error.
+ */
+template<size_t SampleSize = 1>
+[[nodiscard]] inline boost::leaf::result<std::array<temperature, SampleSize>>
+read(temperature_sensor& p_temperature_sensor)
+{
+  std::array<temperature, SampleSize> samples;
+  BOOST_LEAF_CHECK(p_temperature_sensor.read(samples));
+  return samples;
+}
+}  // namespace embed

--- a/tests/temperature/temperature.test.cpp
+++ b/tests/temperature/temperature.test.cpp
@@ -1,5 +1,6 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/temperature/temperature.hpp>
+#include <libembeddedhal/temperature/temperature_util.hpp>
 
 namespace embed {
 namespace {
@@ -7,22 +8,44 @@ constexpr auto expected_temperature = nK(1'000'000'000);
 class test_temperature_sensor : public embed::temperature_sensor
 {
 private:
-  virtual boost::leaf::result<temperature> driver_read() noexcept
+  virtual boost::leaf::result<std::span<temperature>> driver_read(
+    std::span<temperature> p_sample) noexcept
   {
-    return expected_temperature;
+    std::ranges::fill(p_sample, expected_temperature);
+    return p_sample;
   }
 };
 }  // namespace
 
 boost::ut::suite temperature_test = []() {
   using namespace boost::ut;
-  // Setup
-  test_temperature_sensor test;
 
-  // Exercise
-  auto sample = test.read().value();
+  "interface { embed::temperature_sensor }"_test = []() {
+    // Setup
+    test_temperature_sensor test;
+    std::array<temperature, 2> sample{};
 
-  // Verify
-  expect(expected_temperature == sample);
+    // Exercise
+    auto response_span = test.read(sample).value();
+
+    // Verify
+    expect(that % 2 == response_span.size());
+    expect(that % sample.data() == response_span.data());
+    expect(expected_temperature == sample[0]);
+  };
+
+  "read<N>(embed::temperature_sensor)"_test = []() {
+    // Setup
+    test_temperature_sensor test;
+
+    // Exercise
+    auto response_array = read<3>(test).value();
+
+    // Verify
+    expect(that % 3 == response_array.size());
+    expect(expected_temperature == response_array[0]);
+    expect(expected_temperature == response_array[1]);
+    expect(expected_temperature == response_array[2]);
+  };
 };
 }  // namespace embed


### PR DESCRIPTION
Rather than only returning a single sample per function call, an buffer
can be passed into these drivers and have multiple samples returned.

embed::read<N>() overloads have been added for both accelerometer and
temperature_sensor to simplify reading N number of samples from either
driver interface.