### PR TITLE
Add embed::timeout_handler to time.hpp

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,6 +13,7 @@
         "nanometre",
         "nodiscard",
         "pico",
+        "prescalars",
         "tparam"
     ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(${TEST_NAME}
   tests/spi/util.test.cpp
   tests/counter/util.test.cpp
   tests/serial/util.test.cpp
+  tests/timer/util.test.cpp
 
   tests/motor/mock.test.cpp
   tests/pwm/mock.test.cpp

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Examples of this would be `embed::can_network` which takes an `embed::can`
 implementation and manages a map of the messages the device has received on the
 can bus.
 
-Another example is `embed::uptime_counter` which takes an `embed::counter` and
+Another example is `embed::overflow_counter` which takes an `embed::counter` and
 for each call for uptime on the uptime counter, the class checks if the 32-bit
 counter has overflowed. If it has, then increment another 32-bit number with the
 number of overflows counted. Return the result as a 64-bit number which is the

--- a/include/libembeddedhal/counter/overflow_counter.hpp
+++ b/include/libembeddedhal/counter/overflow_counter.hpp
@@ -4,7 +4,7 @@
 
 namespace embed {
 /**
- * @brief uptime counter takes a hardware counter and calculates the uptime in
+ * @brief Overflow counter takes a hardware counter and calculates the uptime in
  * nanoseconds.
  *
  * This class should be used over calling frequency::duration_from_cycles() to
@@ -12,10 +12,10 @@ namespace embed {
  * around 15 weeks have elapsed. This has to do with how the integer arithmetic
  * is handled for converting from frequency to duration using a cycle count.
  *
- * So long as this class's uptime() is called within a 15 week timespan, the
+ * So long as this class's uptime() is called at least once every 15 weeks, the
  * uptime will be accurate up to ~292 years.
  */
-class uptime_counter
+class overflow_counter
 {
 public:
   /**
@@ -23,9 +23,10 @@ public:
    *
    * @param p_counter - hardware counter
    */
-  uptime_counter(counter& p_counter)
+  overflow_counter(counter& p_counter)
     : m_counter(&p_counter)
-  {}
+  {
+  }
 
   /**
    * @brief Calculates the number of nanoseconds since the counter has started

--- a/include/libembeddedhal/time.hpp
+++ b/include/libembeddedhal/time.hpp
@@ -1,19 +1,33 @@
+/**
+ * @file time.hpp
+ * @brief Definitions and utilities for time related operations
+ *
+ */
 #pragma once
 
 #include <chrono>
-#include <functional>
 
 #include "error.hpp"
 
 namespace embed {
-/// Definition of a sleep function
+/// Definition of a delay handler
 /// Delays execution of code based on the amount of time specified. Returns a
 /// clock implementation specific error if there is one.
-using sleep_function =
-  boost::leaf::result<void>(std::chrono::nanoseconds p_sleep_time);
-/// Definition of an uptime function.
+using delay_handler =
+  boost::leaf::result<void>(std::chrono::nanoseconds p_delay_time);
+
+/// Definition of an uptime handler.
 /// Returns the amount of time since the clock has started or a clock
 /// implementation specific error. The uptime resolution depends on the clock
 /// driving it.
-using uptime_function = boost::leaf::result<std::chrono::nanoseconds>(void);
+using uptime_handler = boost::leaf::result<std::chrono::nanoseconds>(void);
+
+/// Definition of a timeout handler
+/// The implementation of the timeout timer will generally use a counter, timer
+/// or other timing system to indicate if a timeout condition has been
+/// satisfied. When the timeout condition is satisfied this handler returns
+/// true. If this handler is called and the condition is not satisfied then it
+/// returns false. If an error has occurred during this operation then an
+/// implementation defined error is returned.
+using timeout_handler = boost::leaf::result<bool>(void);
 }  // namespace embed

--- a/include/libembeddedhal/timer/util.hpp
+++ b/include/libembeddedhal/timer/util.hpp
@@ -1,0 +1,86 @@
+/**
+ * @file util.hpp
+ * @brief Provide utility handlers for the timer interface
+ */
+#pragma once
+
+#include "../time.hpp"
+#include "interface.hpp"
+
+namespace embed {
+/**
+ * @brief Create a timeout handler lambda from a timer that satisfies the
+ * embed::timeout_handler definition.
+ *
+ * @param p_timer - hardware timer driver
+ * @return auto - lambda timeout handler based on the timer
+ */
+[[nodiscard]] inline auto to_timeout(
+  timer& p_timer,
+  std::chrono::nanoseconds p_timeout) noexcept
+{
+  bool first_call = true;
+
+  auto handler =
+    [p_timeout, &p_timer, first_call]() mutable -> boost::leaf::result<bool> {
+    if (first_call) {
+      first_call = false;
+      BOOST_LEAF_CHECK(p_timer.schedule([]() {}, p_timeout));
+    }
+    bool is_running = BOOST_LEAF_CHECK(p_timer.is_running());
+    return !is_running;
+  };
+
+  static_assert(
+    std::is_constructible_v<std::function<timeout_handler>, decltype(handler)>,
+    "[INTERNAL] Callable must be convertible to a embed::uptime_handler");
+
+  return handler;
+}
+
+/**
+ * @brief Delay execution for this duration of time using a hardware timer
+ * object.
+ *
+ * @param p_timer - hardware timer driver
+ * @param p_duration - the amount of time to pause execution for
+ * @return boost::leaf::result<void> - returns an error if a call to p_timer
+ * uptime() results in an error otherwise, returns success.
+ */
+[[nodiscard]] inline boost::leaf::result<void> delay(
+  timer& p_timer,
+  std::chrono::nanoseconds p_duration) noexcept
+{
+  auto timeout = to_timeout(p_timer, p_duration);
+
+  while (!BOOST_LEAF_CHECK(timeout())) {
+    continue;
+  }
+
+  return {};
+}
+
+/**
+ * @brief Create a delay handler lambda using an embed::timer that satisfies
+ * the embed::delay_handler requirement.
+ *
+ * The delay handler will perform a busy wait in order to delay execution.
+ *
+ * @param p_timer - hardware timer driver
+ * @return auto - lambda delay handler based on the timer
+ */
+[[nodiscard]] inline auto to_delay(timer& p_timer) noexcept
+{
+  auto handler =
+    [&p_timer](std::chrono::nanoseconds p_delay) -> boost::leaf::result<void> {
+    BOOST_LEAF_CHECK(delay(p_timer, p_delay));
+    return {};
+  };
+
+  static_assert(
+    std::is_constructible_v<std::function<delay_handler>, decltype(handler)>,
+    "[INTERNAL] Callable must be convertible to a embed::uptime_handler");
+
+  return handler;
+}
+}  // namespace embed

--- a/tests/counter/overflow_counter.test.cpp
+++ b/tests/counter/overflow_counter.test.cpp
@@ -1,5 +1,5 @@
 #include <boost/ut.hpp>
-#include <libembeddedhal/counter/uptime_counter.hpp>
+#include <libembeddedhal/counter/overflow_counter.hpp>
 #include <queue>
 
 namespace embed {
@@ -25,10 +25,10 @@ boost::ut::suite uptime_utility_test = []() {
     embed::frequency m_frequency{ 1'000_MHz };
   };
 
-  "[uptime_counter] zero"_test = []() {
+  "[overflow_counter] zero"_test = []() {
     // Setup
     mock_counter mock;
-    uptime_counter uptime(mock);
+    overflow_counter uptime(mock);
     mock.uptime_sequence.push(0);
     mock.uptime_sequence.push(0);
     mock.uptime_sequence.push(0);
@@ -47,10 +47,10 @@ boost::ut::suite uptime_utility_test = []() {
     expect(that % (0ns).count() == nanoseconds3.count());
   };
 
-  "[uptime_counter] one"_test = []() {
+  "[overflow_counter] one"_test = []() {
     // Setup
     mock_counter mock;
-    uptime_counter uptime(mock);
+    overflow_counter uptime(mock);
     mock.uptime_sequence.push(1);
     mock.uptime_sequence.push(2);
     mock.uptime_sequence.push(3);
@@ -69,10 +69,10 @@ boost::ut::suite uptime_utility_test = []() {
     expect(that % (4ns).count() == nanoseconds3.count());
   };
 
-  "[uptime_counter] many"_test = []() {
+  "[overflow_counter] many"_test = []() {
     // Setup
     mock_counter mock;
-    uptime_counter uptime(mock);
+    overflow_counter uptime(mock);
     mock.uptime_sequence.push(1);
     mock.uptime_sequence.push(20);
     mock.uptime_sequence.push(300);
@@ -109,10 +109,10 @@ boost::ut::suite uptime_utility_test = []() {
     expect(that % (7000005ns).count() == nanoseconds9.count());
   };
 
-  "[uptime_counter] boundaries"_test = []() {
+  "[overflow_counter] boundaries"_test = []() {
     // Setup
     mock_counter mock;
-    uptime_counter uptime(mock);
+    overflow_counter uptime(mock);
     constexpr auto max = std::numeric_limits<uint32_t>::max();
     constexpr auto max_ns = std::chrono::nanoseconds(max);
     constexpr auto d_max = max_ns * 2;
@@ -141,7 +141,7 @@ boost::ut::suite uptime_utility_test = []() {
     expect(that % (d_max + 12'345ns + 2ns).count() == nanoseconds5.count());
   };
 
-  "[uptime_counter] errors"_test = []() {
+  "[overflow_counter] errors"_test = []() {
     // None at the moment
   };
 };

--- a/tests/timer/util.test.cpp
+++ b/tests/timer/util.test.cpp
@@ -1,0 +1,124 @@
+#include <boost/ut.hpp>
+#include <libembeddedhal/timer/util.hpp>
+
+#include "../ostreams.hpp"
+
+namespace embed {
+boost::ut::suite timer_utility_test = []() {
+  using namespace boost::ut;
+
+  class dummy_timer : public embed::timer
+  {
+  public:
+    boost::leaf::result<void> driver_clear() noexcept override { return {}; }
+    boost::leaf::result<bool> driver_is_running() noexcept override
+    {
+      if (m_count < m_delay) {
+        m_count++;
+        return true;
+      }
+      return false;
+    }
+    boost::leaf::result<void> driver_schedule(
+      [[maybe_unused]] std::function<void(void)> p_callback,
+      std::chrono::nanoseconds p_delay) noexcept override
+    {
+      m_delay = p_delay;
+      m_count = std::chrono::nanoseconds(0);
+      return {};
+    }
+
+    std::chrono::nanoseconds m_delay{ 0 };
+    std::chrono::nanoseconds m_count{ 0 };
+  };
+
+  "embed::delay(embed::timer, 0ns)"_test = []() {
+    // Setup
+    constexpr std::chrono::nanoseconds expected(0);
+    dummy_timer test_timer;
+
+    // Exercise
+    delay(test_timer, expected);
+
+    // Verify
+    expect(that % expected == test_timer.m_count);
+    expect(that % expected == test_timer.m_delay);
+  };
+
+  "embed::delay(embed::timer, 50ns)"_test = []() {
+    // Setup
+    constexpr std::chrono::nanoseconds expected(50);
+    dummy_timer test_timer;
+
+    // Exercise
+    delay(test_timer, expected);
+
+    // Verify
+    expect(that % expected == test_timer.m_count);
+    expect(that % expected == test_timer.m_delay);
+  };
+
+  "embed::delay(embed::timer, 1337ns)"_test = []() {
+    // Setup
+    constexpr std::chrono::nanoseconds expected(1337);
+    dummy_timer test_timer;
+
+    // Exercise
+    delay(test_timer, expected);
+
+    // Verify
+    expect(that % expected == test_timer.m_count);
+    expect(that % expected == test_timer.m_delay);
+  };
+
+  // ====== TO SLEEP ======
+
+  "Verify that embed::to_delay() returns embed::delay_handler"_test = []() {
+    // Setup
+    dummy_timer test_timer;
+
+    // Exercise
+    [[maybe_unused]] std::function<embed::delay_handler> test_subject =
+      to_delay(test_timer);
+  };
+
+  "embed::to_delay(embed::timer)(0ns)"_test = []() {
+    // Setup
+    constexpr std::chrono::nanoseconds expected(0);
+    dummy_timer test_timer;
+
+    // Exercise
+    to_delay(test_timer)(expected);
+
+    // Verify
+    expect(that % expected == test_timer.m_count);
+    expect(that % expected == test_timer.m_delay);
+  };
+
+  "embed::to_delay(embed::timer)(50ns)"_test = []() {
+    // Setup
+    constexpr std::chrono::nanoseconds expected(50);
+    dummy_timer test_timer;
+
+    // Exercise
+    to_delay(test_timer)(expected);
+
+    // Verify
+    expect(that % expected == test_timer.m_count);
+    expect(that % expected == test_timer.m_delay);
+  };
+
+  "embed::to_delay(embed::timer)(1337ns)"_test = []() {
+    // Setup
+    constexpr std::chrono::nanoseconds expected(1337);
+    dummy_timer test_timer;
+
+    // Exercise
+    to_delay(test_timer)(expected);
+
+    // Verify
+    expect(that % expected == test_timer.m_count);
+    expect(that % expected == test_timer.m_delay);
+  };
+};
+}  // namespace embed


### PR DESCRIPTION
- timeout_handler returns a true if the handler has expired or false if
  it hasn't. An error if an error occured when calling the timeout
  function.
- timeout_timer can be used as the foundation for polling and delaying
  operations.
- Rename uptime_counter to overflow_counter as the previous name was
  confusing.
- Add to_timeout(counter&) w/ unit tests
- Add to_timeout(timer&) w/ unit tests
- Add to_timeout(serial&) w/ unit tests

Resolves #79