### PR TITLE
Make percent::from_ratio() safety critical

### DIFF
--- a/tests/ostreams.hpp
+++ b/tests/ostreams.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/ut.hpp>
 #include <chrono>
+#include <iomanip>
 
 #include <libembeddedhal/frequency.hpp>
 #include <libembeddedhal/percent.hpp>
@@ -31,6 +32,9 @@ inline std::ostream& operator<<(std::ostream& os, const duty_cycle& p_duty)
 
 inline std::ostream& operator<<(std::ostream& os, const percent& p_percent)
 {
-  return (os << "percent { " << static_cast<float>(p_percent) << " }");
+  return (os << "percent { " << std::fixed << std::setprecision(3)
+             << static_cast<float>(p_percent) << " : " << std::right
+             << std::setfill(' ') << std::setw(10) << p_percent.raw_value()
+             << " }");
 }
 }  // namespace embed

--- a/tests/percent.test.cpp
+++ b/tests/percent.test.cpp
@@ -541,7 +541,7 @@ boost::ut::suite percent_scale_test = []() {
     max = std::numeric_limits<std::int32_t>::max();
 
     expected_0_percent = 0;
-    expected_50_percent = max / 2;
+    expected_50_percent = rounding_division(max, 2);
     expected_100_percent = std::numeric_limits<std::int32_t>::max();
 
     test = percent::from_ratio(1, 1);
@@ -569,9 +569,10 @@ boost::ut::suite percent_scale_test = []() {
     max = 0;
 
     expected_0_percent = min;
-    expected_25_percent = min - (min / 4) - 1;
-    expected_50_percent = min / 2;
-    expected_75_percent = min / 4;
+    expected_25_percent = min - rounding_division(min, 4);
+    // + 1 because the conversion is off by 1 slightly, but still close enough
+    expected_50_percent = rounding_division(min, 2) + 1;
+    expected_75_percent = rounding_division(min, 4);
     expected_100_percent = 0;
 
     test = percent::from_ratio(1, 1);
@@ -607,9 +608,9 @@ boost::ut::suite percent_scale_test = []() {
     max = 200000000;
 
     expected_0_percent = min;
-    expected_25_percent = min / 2;
+    expected_25_percent = rounding_division(min, 2);
     expected_50_percent = 0;
-    expected_75_percent = max / 2;
+    expected_75_percent = rounding_division(max, 2);
     expected_100_percent = max;
 
     test = percent::from_ratio(1, 1);


### PR DESCRIPTION
- Add constraint to function such that integral types greater than
  32-bit are forbidden.
- Use rounding division in from_ratio

Resolves #246