### PR TITLE
Migrate to std::errc as default error type

### DIFF
--- a/include/libembeddedhal/can/interface.hpp
+++ b/include/libembeddedhal/can/interface.hpp
@@ -49,9 +49,8 @@ public:
    * @brief Configure can to match the settings supplied
    *
    * @param p_settings - settings to apply to can driver
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation. Will return embed::error::invalid_settings if the settings could
-   * not be achieved.
+   * @return boost::leaf::result<void>
+   * @throws std::errc::invalid_argument if the settings could not be achieved.
    */
   [[nodiscard]] boost::leaf::result<void> configure(
     const settings& p_settings) noexcept

--- a/include/libembeddedhal/counter/timeout.hpp
+++ b/include/libembeddedhal/counter/timeout.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <system_error>
+
 #include "../frequency.hpp"
 #include "interface.hpp"
 
@@ -62,7 +64,7 @@ public:
    * @brief Call this object to check if it has timed out.
    *
    * @return boost::leaf::result<void>
-   * @throws embed::error::timeout - if the number of cycles until timeout has
+   * @throws std::errc::timed_out - if the number of cycles until timeout has
    * been exceeded.
    */
   boost::leaf::result<void> operator()() noexcept
@@ -72,7 +74,7 @@ public:
     m_cycles_until_timeout -= delta_count;
 
     if (m_cycles_until_timeout <= 0) {
-      return boost::leaf::new_error(embed::error::timeout{});
+      return boost::leaf::new_error(std::errc::timed_out);
     }
 
     m_previous_count = current_count;

--- a/include/libembeddedhal/counter/util.hpp
+++ b/include/libembeddedhal/counter/util.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <system_error>
 
 #include "../error.hpp"
 #include "../timeout.hpp"

--- a/include/libembeddedhal/error.hpp
+++ b/include/libembeddedhal/error.hpp
@@ -23,7 +23,4 @@ struct invalid_option_t : std::false_type
  */
 template<auto... options>
 inline constexpr bool invalid_option = invalid_option_t<options...>::value;
-
-struct invalid_settings
-{};
 }  // namespace embed::error

--- a/include/libembeddedhal/i2c/interface.hpp
+++ b/include/libembeddedhal/i2c/interface.hpp
@@ -96,7 +96,7 @@ public:
    *
    * @param p_settings - settings to apply to i2c driver
    * @return boost::leaf::result<void> - any error that occurred during this
-   * operation. Will return embed::error::invalid_settings if the settings could
+   * operation. Will return std::errc::invalid_argument if the settings could
    * not be achieved.
    */
   [[nodiscard]] boost::leaf::result<void> configure(

--- a/include/libembeddedhal/input_pin/interface.hpp
+++ b/include/libembeddedhal/input_pin/interface.hpp
@@ -37,9 +37,8 @@ public:
    * @brief Configure the input pin to match the settings supplied
    *
    * @param p_settings - settings to apply to input pin
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation. Will return embed::error::invalid_settings if the settings could
-   * not be achieved.
+   * @return boost::leaf::result<void>
+   * @throws std::errc::invalid_argument if the settings could not be achieved.
    */
   [[nodiscard]] boost::leaf::result<void> configure(
     const settings& p_settings) noexcept

--- a/include/libembeddedhal/interrupt_pin/interface.hpp
+++ b/include/libembeddedhal/interrupt_pin/interface.hpp
@@ -48,9 +48,8 @@ public:
    * @brief Configure the interrupt pin to match the settings supplied
    *
    * @param p_settings - settings to apply to interrupt pin
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation. Will return embed::error::invalid_settings if the settings could
-   * not be achieved.
+   * @return boost::leaf::result<void>
+   * @throws std::errc::invalid_argument if the settings could not be achieved.
    */
   [[nodiscard]] boost::leaf::result<void> configure(
     const settings& p_settings) noexcept
@@ -60,8 +59,7 @@ public:
   /**
    * @brief Return the voltage level of the pin
    *
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation.
+   * @return boost::leaf::result<void>
    */
   [[nodiscard]] boost::leaf::result<bool> level() noexcept
   {
@@ -77,8 +75,7 @@ public:
    * @param p_callback function to execute when the trigger condition is met
    * @param p_trigger the trigger condition that will signal the system to run
    * the callback.
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation.
+   * @return boost::leaf::result<void>
    */
   [[nodiscard]] boost::leaf::result<void> attach_interrupt(
     std::function<void(void)> p_callback,

--- a/include/libembeddedhal/output_pin/interface.hpp
+++ b/include/libembeddedhal/output_pin/interface.hpp
@@ -45,9 +45,8 @@ public:
    * @brief Configure the output pin to match the settings supplied
    *
    * @param p_settings - settings to apply to output pin
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation. Will return embed::error::invalid_settings if the settings could
-   * not be achieved.
+   * @return boost::leaf::result<void>
+   * @throws std::errc::invalid_argument if the settings could not be achieved.
    */
   [[nodiscard]] boost::leaf::result<void> configure(
     const settings& p_settings) noexcept

--- a/include/libembeddedhal/pwm/interface.hpp
+++ b/include/libembeddedhal/pwm/interface.hpp
@@ -39,9 +39,8 @@ public:
    * @brief Configure pwm to match the settings supplied
    *
    * @param p_settings - settings to apply to pwm driver
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation. Will return embed::error::invalid_settings if the settings could
-   * not be achieved.
+   * @return boost::leaf::result<void>
+   * @throws std::errc::invalid_argument if the settings could not be achieved.
    */
   [[nodiscard]] boost::leaf::result<void> configure(
     const settings& p_settings) noexcept

--- a/include/libembeddedhal/serial/interface.hpp
+++ b/include/libembeddedhal/serial/interface.hpp
@@ -137,9 +137,8 @@ public:
    * @brief Configure serial to match the settings supplied
    *
    * @param p_settings - settings to apply to serial driver
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation. Will return embed::error::invalid_settings if the settings could
-   * not be achieved.
+   * @return boost::leaf::result<void>
+   * @throws std::errc::invalid_argument if the settings could not be achieved.
    */
   [[nodiscard]] boost::leaf::result<void> configure(
     const settings& p_settings) noexcept
@@ -165,8 +164,7 @@ public:
    *
    * @param p_data - data to be transmitted over the serial port transmitter
    * line
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation.
+   * @return boost::leaf::result<void>
    */
   [[nodiscard]] boost::leaf::result<void> write(
     std::span<const std::byte> p_data) noexcept
@@ -209,8 +207,7 @@ public:
    * @brief Set bytes_available() to zero and clear any received data stored in
    * hardware registers.
    *
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation.
+   * @return boost::leaf::result<void>
    */
   [[nodiscard]] boost::leaf::result<void> flush() noexcept
   {

--- a/include/libembeddedhal/spi/interface.hpp
+++ b/include/libembeddedhal/spi/interface.hpp
@@ -48,9 +48,8 @@ public:
    * @brief Configure spi to match the settings supplied
    *
    * @param p_settings - settings to apply to spi
-   * @return boost::leaf::result<void> - any error that occurred during this
-   * operation. Will return embed::error::invalid_settings if the settings could
-   * not be achieved.
+   * @return boost::leaf::result<void>
+   * @throws std::errc::invalid_argument if the settings could not be achieved.
    */
   [[nodiscard]] boost::leaf::result<void> configure(
     const settings& p_settings) noexcept

--- a/tests/counter/util.test.cpp
+++ b/tests/counter/util.test.cpp
@@ -42,13 +42,13 @@ boost::ut::suite counter_utility_test = []() {
       [&timeout_object]() -> boost::leaf::result<void> {
         return timeout_object();
       },
-      [&success]([[maybe_unused]] embed::error::timeout p_error) {
+      [&success](boost::leaf::match<std::errc, std::errc::timed_out>) {
         success = true;
       },
-      []() { expect(false) << "embed::error::timeout was not thrown!"; });
+      []() { expect(false) << "std::errc::timed_out was not thrown!"; });
 
     // Verify
-    expect(that % success) << "embed::error::timeout handler was not called!";
+    expect(that % success) << "std::errc::timed_out handler was not called!";
     // Verify: subtract 2 because 2 invocations are required in order to get
     //         the start uptime and another to check what the latest uptime is.
     expect(that % expected.count() ==
@@ -75,13 +75,13 @@ boost::ut::suite counter_utility_test = []() {
         }
         return timeout_object();
       },
-      [&success]([[maybe_unused]] embed::error::timeout p_error) {
+      [&success](boost::leaf::match<std::errc, std::errc::timed_out>) {
         success = true;
       },
-      []() { expect(false) << "embed::error::timeout was not thrown!"; });
+      []() { expect(false) << "std::errc::timed_out was not thrown!"; });
 
     // Verify
-    expect(that % success) << "embed::error::timeout handler was not called!";
+    expect(that % success) << "std::errc::timed_out handler was not called!";
     expect(that % expected.count() ==
            (test_counter.get_internal_uptime().count));
     expect(that % expected_frequency ==
@@ -106,13 +106,13 @@ boost::ut::suite counter_utility_test = []() {
         }
         return timeout_object();
       },
-      [&success]([[maybe_unused]] embed::error::timeout p_error) {
+      [&success](boost::leaf::match<std::errc, std::errc::timed_out>) {
         success = true;
       },
-      []() { expect(false) << "embed::error::timeout was not thrown!"; });
+      []() { expect(false) << "std::errc::timed_out was not thrown!"; });
 
     // Verify
-    expect(that % success) << "embed::error::timeout handler was not called!";
+    expect(that % success) << "std::errc::timed_out handler was not called!";
     expect(that % expected.count() ==
            (test_counter.get_internal_uptime().count));
     expect(that % expected_frequency ==

--- a/tests/timeout.test.cpp
+++ b/tests/timeout.test.cpp
@@ -12,7 +12,7 @@ boost::ut::suite timeout_test = []() {
     auto timeout_function = [&counts]() mutable -> boost::leaf::result<void> {
       counts++;
       if (counts >= timeout_call_limit) {
-        return boost::leaf::new_error(embed::error::timeout{});
+        return boost::leaf::new_error(std::errc::timed_out);
       }
       return {};
     };


### PR DESCRIPTION
Migrate from custom LEH error types to using std::errc types where it
makes sense. The purpose of this is to reduce the number of error types
used in the system, which in turn reduces the number of error types that
have to be allocated in thread control blocks.