### PR TITLE
Move counter_timeout to factory scheme

### DIFF
--- a/include/libembeddedhal/counter/util.hpp
+++ b/include/libembeddedhal/counter/util.hpp
@@ -28,12 +28,7 @@ inline boost::leaf::result<embed::counter_timeout> create_timeout(
   embed::counter& p_counter,
   embed::time_duration p_duration)
 {
-  if (p_duration < embed::time_duration(0)) {
-    return boost::leaf::new_error(std::errc::result_out_of_range);
-  }
-  const auto [frequency, count] = BOOST_LEAF_CHECK(p_counter.uptime());
-  auto cycles = cycles_per(frequency, p_duration);
-  return embed::counter_timeout(p_counter, cycles);
+  return embed::counter_timeout::create(p_counter, p_duration);
 }
 
 /**


### PR DESCRIPTION
This will ensure that if a counter_timeout object is created, it must be
done through a factory function.

Also allows counter_timeout to be used on its own rather than just
create_timeout or performing the work manually.