### PR TITLE
Add timeout to i2c::transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,12 +612,12 @@ int main()
     },
     // Functions after the first are the handlers.
     // In this case, we only check for embed::i2c::errors.
-    [](embed::i2c::errors p_error) {
+    [](std::errc p_error) {
       switch(p_error) {
-        case embed::i2c::errors::address_not_acknowledged:
+        case std::errc::no_such_device_or_address:
           // Handle this case here...
           break;
-        case embed::i2c::errors::bus_error:
+        case std::errc::io_error:
           // Handle this case here...
           break;
       }

--- a/include/libembeddedhal/i2c/util.hpp
+++ b/include/libembeddedhal/i2c/util.hpp
@@ -3,6 +3,8 @@
  */
 #pragma once
 
+#include <functional>
+
 #include "../error.hpp"
 #include "interface.hpp"
 
@@ -19,14 +21,17 @@ namespace embed {
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @param p_data_out - buffer of bytes to write to the target device
+ * @param p_timeout - amount of time to execute the transaction
  * @return boost::leaf::result<void> - any errors associated with the read call
  */
 [[nodiscard]] inline boost::leaf::result<void> write(
   i2c& p_i2c,
   std::byte p_address,
-  std::span<const std::byte> p_data_out) noexcept
+  std::span<const std::byte> p_data_out,
+  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
 {
-  return p_i2c.transaction(p_address, p_data_out, std::span<std::byte>{});
+  return p_i2c.transaction(
+    p_address, p_data_out, std::span<std::byte>{}, p_timeout);
 }
 /**
  * @brief read bytes from target device on i2c bus
@@ -36,12 +41,17 @@ namespace embed {
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @param p_data_in - buffer to read bytes into from target device
+ * @param p_timeout - amount of time to execute the transaction
  * @return boost::leaf::result<void> - any errors associated with the read call
  */
-[[nodiscard]] inline boost::leaf::result<void>
-read(i2c& p_i2c, std::byte p_address, std::span<std::byte> p_data_in) noexcept
+[[nodiscard]] inline boost::leaf::result<void> read(
+  i2c& p_i2c,
+  std::byte p_address,
+  std::span<std::byte> p_data_in,
+  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
 {
-  return p_i2c.transaction(p_address, std::span<std::byte>{}, p_data_in);
+  return p_i2c.transaction(
+    p_address, std::span<std::byte>{}, p_data_in, p_timeout);
 }
 /**
  * @brief return array of read bytes from target device on i2c bus
@@ -51,16 +61,18 @@ read(i2c& p_i2c, std::byte p_address, std::span<std::byte> p_data_in) noexcept
  * @tparam BytesToRead - number of bytes to read
  * @param p_i2c - i2c driver
  * @param p_address - target address
+ * @param p_timeout - amount of time to execute the transaction
  * @return boost::leaf::result<std::array<std::byte, BytesToRead>> - array of
  * bytes from target device or an error.
  */
 template<size_t BytesToRead>
 [[nodiscard]] boost::leaf::result<std::array<std::byte, BytesToRead>> read(
   i2c& p_i2c,
-  std::byte p_address) noexcept
+  std::byte p_address,
+  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
 {
   std::array<std::byte, BytesToRead> buffer;
-  BOOST_LEAF_CHECK(read(p_i2c, p_address, buffer));
+  BOOST_LEAF_CHECK(read(p_i2c, p_address, buffer, p_timeout));
   return buffer;
 }
 /**
@@ -73,6 +85,7 @@ template<size_t BytesToRead>
  * @param p_address - target address
  * @param p_data_out - buffer of bytes to write to the target device
  * @param p_data_in - buffer to read bytes into from target device
+ * @param p_timeout - amount of time to execute the transaction
  *
  * @return boost::leaf::result<void> - any errors associated with the read call
  */
@@ -80,9 +93,10 @@ template<size_t BytesToRead>
   i2c& p_i2c,
   std::byte p_address,
   std::span<const std::byte> p_data_out,
-  std::span<std::byte> p_data_in) noexcept
+  std::span<std::byte> p_data_in,
+  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
 {
-  return p_i2c.transaction(p_address, p_data_out, p_data_in);
+  return p_i2c.transaction(p_address, p_data_out, p_data_in, p_timeout);
 }
 /**
  * @brief write and then return an array of read bytes from target device on i2c
@@ -94,16 +108,20 @@ template<size_t BytesToRead>
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @param p_data_out - buffer of bytes to write to the target device
+ * @param p_timeout - amount of time to execute the transaction
  * @return boost::leaf::result<std::array<std::byte, BytesToRead>>
  */
 template<size_t BytesToRead>
 [[nodiscard]] boost::leaf::result<std::array<std::byte, BytesToRead>>
-write_then_read(i2c& p_i2c,
-                std::byte p_address,
-                std::span<const std::byte> p_data_out) noexcept
+write_then_read(
+  i2c& p_i2c,
+  std::byte p_address,
+  std::span<const std::byte> p_data_out,
+  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
 {
   std::array<std::byte, BytesToRead> buffer;
-  BOOST_LEAF_CHECK(write_then_read(p_i2c, p_address, p_data_out, buffer));
+  BOOST_LEAF_CHECK(
+    write_then_read(p_i2c, p_address, p_data_out, buffer, p_timeout));
   return buffer;
 }
 /// @}

--- a/include/libembeddedhal/timeout.hpp
+++ b/include/libembeddedhal/timeout.hpp
@@ -25,7 +25,7 @@ namespace embed {
  * @returns boost::leaf::result<void> - sets error flag set when timeout
  * condition has been met, otherwise returns success.
  */
-using timeout = boost::leaf::result<void>(void) noexcept;
+using timeout = boost::leaf::result<void>(void);
 
 /**
  * @brief Delay the execution of the application or thread for a duration of
@@ -58,6 +58,16 @@ template<typename Timeout = std::function<embed::timeout>>
   }
 
   return {};
+}
+
+/**
+ * @brief Create a timeout that will never time out
+ *
+ * @return auto - callable that will never return timeout
+ */
+[[nodiscard]] inline auto never_timeout() noexcept
+{
+  return []() -> boost::leaf::result<void> { return {}; };
 }
 /** @} */
 }  // namespace embed

--- a/tests/i2c/util.test.cpp
+++ b/tests/i2c/util.test.cpp
@@ -10,7 +10,17 @@ boost::ut::suite i2c_util_test = []() {
   static constexpr std::byte failure_address{ 0x33 };
   static constexpr std::byte filler_byte{ 0xA5 };
 
-  class dummy : public embed::i2c
+  struct test_timeout_t
+  {
+    boost::leaf::result<void> operator()()
+    {
+      was_called = true;
+      return {};
+    }
+    bool was_called = false;
+  };
+
+  class test_i2c : public embed::i2c
   {
   public:
     [[nodiscard]] boost::leaf::result<void> driver_configure(
@@ -21,7 +31,8 @@ boost::ut::suite i2c_util_test = []() {
     [[nodiscard]] boost::leaf::result<void> driver_transaction(
       std::byte p_address,
       std::span<const std::byte> p_out,
-      std::span<std::byte> p_in) noexcept override
+      std::span<std::byte> p_in,
+      std::function<embed::timeout> p_timeout) noexcept override
     {
       m_address = p_address;
       m_out = p_out;
@@ -33,10 +44,14 @@ boost::ut::suite i2c_util_test = []() {
         return boost::leaf::new_error();
       }
 
+      (void)p_timeout();
+
       return {};
     }
 
-    virtual ~dummy() {}
+    virtual ~test_i2c()
+    {
+    }
 
     std::byte m_address = std::byte{ 0 };
     std::span<const std::byte> m_out = std::span<const std::byte>{};
@@ -45,11 +60,13 @@ boost::ut::suite i2c_util_test = []() {
 
   "[success] write"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
     const std::array<std::byte, 4> expected_payload{};
 
     // Exercise
-    auto result = write(i2c, successful_address, expected_payload);
+    auto result =
+      write(i2c, successful_address, expected_payload, std::ref(test_timeout));
     bool successful = static_cast<bool>(result);
 
     // Verify
@@ -59,15 +76,18 @@ boost::ut::suite i2c_util_test = []() {
     expect(that % expected_payload.size() == i2c.m_out.size());
     expect(that % nullptr == i2c.m_in.data());
     expect(that % 0 == i2c.m_in.size());
+    expect(that % true == test_timeout.was_called);
   };
 
   "[failure] write"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
     const std::array<std::byte, 4> expected_payload{};
 
     // Exercise
-    auto result = write(i2c, failure_address, expected_payload);
+    auto result =
+      write(i2c, failure_address, expected_payload, std::ref(test_timeout));
     bool successful = static_cast<bool>(result);
 
     // Verify
@@ -77,15 +97,18 @@ boost::ut::suite i2c_util_test = []() {
     expect(that % expected_payload.size() == i2c.m_out.size());
     expect(that % nullptr == i2c.m_in.data());
     expect(that % 0 == i2c.m_in.size());
+    expect(that % false == test_timeout.was_called);
   };
 
   "[success] read"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
     std::array<std::byte, 4> expected_buffer;
 
     // Exercise
-    auto result = read(i2c, successful_address, expected_buffer);
+    auto result =
+      read(i2c, successful_address, expected_buffer, std::ref(test_timeout));
     bool successful = static_cast<bool>(result);
 
     // Verify
@@ -95,15 +118,18 @@ boost::ut::suite i2c_util_test = []() {
     expect(that % expected_buffer.size() == i2c.m_in.size());
     expect(that % nullptr == i2c.m_out.data());
     expect(that % 0 == i2c.m_out.size());
+    expect(that % true == test_timeout.was_called);
   };
 
   "[failure] read"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
     std::array<std::byte, 4> expected_buffer;
 
     // Exercise
-    auto result = read(i2c, failure_address, expected_buffer);
+    auto result =
+      read(i2c, failure_address, expected_buffer, std::ref(test_timeout));
     bool successful = static_cast<bool>(result);
 
     // Verify
@@ -113,16 +139,19 @@ boost::ut::suite i2c_util_test = []() {
     expect(that % expected_buffer.size() == i2c.m_in.size());
     expect(that % nullptr == i2c.m_out.data());
     expect(that % 0 == i2c.m_out.size());
+    expect(that % false == test_timeout.was_called);
   };
 
   "[success] read<Length>"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
     std::array<std::byte, 5> expected_buffer;
     expected_buffer.fill(filler_byte);
 
     // Exercise
-    auto result = read<expected_buffer.size()>(i2c, successful_address);
+    auto result = read<expected_buffer.size()>(
+      i2c, successful_address, std::ref(test_timeout));
     bool successful = static_cast<bool>(result);
 
     // Verify
@@ -132,11 +161,13 @@ boost::ut::suite i2c_util_test = []() {
       expected_buffer.begin(), expected_buffer.end(), result.value().begin()));
     expect(that % nullptr == i2c.m_out.data());
     expect(that % 0 == i2c.m_out.size());
+    expect(that % true == test_timeout.was_called);
   };
 
   "[failure] read<Length>"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
 
     // Exercise
     auto result = read<5>(i2c, failure_address);
@@ -147,17 +178,22 @@ boost::ut::suite i2c_util_test = []() {
     expect(failure_address == i2c.m_address);
     expect(that % nullptr == i2c.m_out.data());
     expect(that % 0 == i2c.m_out.size());
+    expect(that % false == test_timeout.was_called);
   };
 
   "[success] write_then_read"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
     const std::array<std::byte, 4> expected_payload{};
     std::array<std::byte, 4> expected_buffer;
 
     // Exercise
-    auto result = write_then_read(
-      i2c, successful_address, expected_payload, expected_buffer);
+    auto result = write_then_read(i2c,
+                                  successful_address,
+                                  expected_payload,
+                                  expected_buffer,
+                                  std::ref(test_timeout));
     bool successful = static_cast<bool>(result);
 
     // Verify
@@ -167,18 +203,23 @@ boost::ut::suite i2c_util_test = []() {
     expect(that % expected_payload.size() == i2c.m_out.size());
     expect(that % expected_buffer.data() == i2c.m_in.data());
     expect(that % expected_buffer.size() == i2c.m_in.size());
+    expect(that % true == test_timeout.was_called);
   };
 
   "[failure] write_then_read"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
     const std::array<std::byte, 4> expected_payload{};
     std::array<std::byte, 4> expected_buffer;
     expected_buffer.fill(filler_byte);
 
     // Exercise
-    auto result =
-      write_then_read(i2c, failure_address, expected_payload, expected_buffer);
+    auto result = write_then_read(i2c,
+                                  failure_address,
+                                  expected_payload,
+                                  expected_buffer,
+                                  std::ref(test_timeout));
     bool successful = static_cast<bool>(result);
 
     // Verify
@@ -188,17 +229,20 @@ boost::ut::suite i2c_util_test = []() {
     expect(that % expected_payload.size() == i2c.m_out.size());
     expect(that % expected_buffer.data() == i2c.m_in.data());
     expect(that % expected_buffer.size() == i2c.m_in.size());
+    expect(that % false == test_timeout.was_called);
   };
 
   "[success] write_then_read<Length>"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
     const std::array<std::byte, 4> expected_payload{};
     std::array<std::byte, 4> expected_buffer{};
     expected_buffer.fill(filler_byte);
 
     // Exercise
-    auto result = write_then_read<5>(i2c, successful_address, expected_payload);
+    auto result = write_then_read<5>(
+      i2c, successful_address, expected_payload, std::ref(test_timeout));
     bool successful = static_cast<bool>(result);
     auto actual_array = result.value();
 
@@ -209,15 +253,18 @@ boost::ut::suite i2c_util_test = []() {
     expect(that % expected_payload.size() == i2c.m_out.size());
     expect(std::equal(
       expected_buffer.begin(), expected_buffer.end(), actual_array.begin()));
+    expect(that % true == test_timeout.was_called);
   };
 
   "[failure] write_then_read<Length>"_test = []() {
     // Setup
-    dummy i2c;
+    test_i2c i2c;
+    test_timeout_t test_timeout;
     const std::array<std::byte, 4> expected_payload{};
 
     // Exercise
-    auto result = write_then_read<5>(i2c, failure_address, expected_payload);
+    auto result = write_then_read<5>(
+      i2c, failure_address, expected_payload, std::ref(test_timeout));
     bool successful = static_cast<bool>(result);
 
     // Verify
@@ -225,6 +272,7 @@ boost::ut::suite i2c_util_test = []() {
     expect(failure_address == i2c.m_address);
     expect(that % expected_payload.data() == i2c.m_out.data());
     expect(that % expected_payload.size() == i2c.m_out.size());
+    expect(that % false == test_timeout.was_called);
   };
 };
 }  // namespace embed


### PR DESCRIPTION
- Migrate to std::errc for transaction errors

Resolves #332