### PR TITLE
Alias standard boost::leaf types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_executable(${TEST_NAME}
   tests/main.test.cpp
   tests/overflow_counter.test.cpp
   tests/math.test.cpp
+  tests/error.test.cpp
   tests/map.test.cpp)
 
 enable_testing()

--- a/include/libembeddedhal/config.hpp
+++ b/include/libembeddedhal/config.hpp
@@ -5,6 +5,8 @@
 namespace embed::config {
 namespace defaults {
 constexpr std::string_view platform = "test";
+constexpr bool on_error_callback_enabled = false;
+constexpr auto on_error_callback = []() {};
 }  // namespace defaults
 using namespace defaults;
 }  // namespace embed::config

--- a/include/libembeddedhal/error.hpp
+++ b/include/libembeddedhal/error.hpp
@@ -1,8 +1,40 @@
 #pragma once
 
+#include <system_error>
+
+#include "config.hpp"
 #include "internal/third_party/leaf.hpp"
 
-namespace embed::error {
+namespace embed {
+
+template<class T>
+using result = boost::leaf::result<T>;
+using status = boost::leaf::result<void>;
+
+template<class TryBlock, class... H>
+[[nodiscard]] constexpr auto attempt(TryBlock&& p_try_block, H&&... p_handlers)
+{
+  return boost::leaf::try_handle_some(p_try_block, p_handlers...);
+}
+
+template<class TryBlock, class... H>
+[[nodiscard]] constexpr auto attempt_all(TryBlock&& p_try_block,
+                                         H&&... p_handlers)
+{
+  return boost::leaf::try_handle_all(p_try_block, p_handlers...);
+}
+
+template<class... Item>
+inline auto new_error(Item&&... p_item) noexcept
+{
+  if constexpr (config::on_error_callback_enabled) {
+    config::on_error_callback();
+  }
+
+  return boost::leaf::new_error(std::forward<Item>(p_item)...);
+}
+
+namespace error {
 /**
  * @brief Used for defining static_asserts that should always fail, but only if
  * the static_assert line is hit via `if constexpr` control block. Prefer to NOT
@@ -23,4 +55,5 @@ struct invalid_option_t : std::false_type
  */
 template<auto... options>
 inline constexpr bool invalid_option = invalid_option_t<options...>::value;
-}  // namespace embed::error
+}  // namespace error
+}  // namespace embed

--- a/tests/error.test.cpp
+++ b/tests/error.test.cpp
@@ -1,0 +1,57 @@
+#include <boost/ut.hpp>
+#include <libembeddedhal/error.hpp>
+
+namespace embed {
+boost::ut::suite error_test = []() {
+  using namespace boost::ut;
+
+  "[success] embed::on_error calls callback"_test = []() {
+    // Setup
+    auto current_call_count = config::callback_call_count;
+    expect(that % current_call_count == config::callback_call_count);
+
+    // Exercise
+    // Should call the `on_error_callback` defined in the tweaks file
+    (void)new_error();
+
+    // Verify
+    expect(that % current_call_count < config::callback_call_count);
+  };
+
+  "[success] embed::attempt calls handler"_test = []() {
+    // Setup
+    constexpr int expected = 123456789;
+    int value_to_be_change = 0;
+
+    // Exercise
+    // Should call the `on_error_callback` defined in the tweaks file
+    auto result =
+      attempt([expected]() -> status { return new_error(expected); },
+              [&value_to_be_change](int p_handler_value) -> status {
+                value_to_be_change = p_handler_value;
+                return {};
+              });
+
+    // Verify
+    expect(that % value_to_be_change == expected);
+    expect(that % true == bool{ result });
+  };
+
+  "[success] embed::attempt calls handler"_test = []() {
+    // Setup
+    constexpr int expected = 123456789;
+    int value_to_be_change = 0;
+
+    // Exercise
+    // Should call the `on_error_callback` defined in the tweaks file
+
+    attempt_all(
+      [expected]() -> status { return new_error(); },
+      [&value_to_be_change](int) {},
+      [&value_to_be_change, expected]() { value_to_be_change = expected; });
+
+    // Verify
+    expect(that % value_to_be_change == expected);
+  };
+};
+}  // namespace embed

--- a/tests/libembeddedhal.tweaks.hpp
+++ b/tests/libembeddedhal.tweaks.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 namespace embed::config {
-constexpr bool get_stacktrace_on_error = true;
-constexpr bool get_source_position_on_error = true;
+inline int callback_call_count = 0;
+constexpr bool on_error_callback_enabled = true;
+constexpr auto on_error_callback = []() { callback_call_count++; };
 }  // namespace embed::config


### PR DESCRIPTION
- Add embed::on_error (alias of boost::leaf::new_error)
- Add embed::result (alias of boost::leaf::result<T>)
- Add embed::status (alias of boost::leaf::result<void>)
- Add embed::attempt (alias of boost::leaf::try_handle_some)
- Add embed::attempt_all (alias of boost::leaf::try_handle_all)

Resolves https://github.com/libembeddedhal/libembeddedhal/issues/343