### PR TITLE
Change namespace to "hal"

### DIFF
--- a/include/libembeddedhal/adc/interface.hpp
+++ b/include/libembeddedhal/adc/interface.hpp
@@ -5,7 +5,7 @@
 #include "../error.hpp"
 #include "../percent.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup adc
  * Available Analog to Digital Converter (ADC) APIs
@@ -35,7 +35,7 @@ public:
    *
    * @return boost::leaf::result<percent> - Return the value of the
    * ADC as a full_scale value. Typical implementation for a 12-bit adc would
-   * look like: `return embed::bit_depth<uint32_t, 12>(adc_value);`.
+   * look like: `return hal::bit_depth<uint32_t, 12>(adc_value);`.
    *
    */
   [[nodiscard]] boost::leaf::result<percent> read() noexcept
@@ -47,4 +47,4 @@ private:
   virtual boost::leaf::result<percent> driver_read() noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/adc/mock.hpp
+++ b/include/libembeddedhal/adc/mock.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup adc
  * @{
@@ -9,21 +9,21 @@ namespace embed::mock {
 /**
  * @brief Mock adc implementation for use in unit tests and simulations.
  */
-struct adc : public embed::adc
+struct adc : public hal::adc
 {
   /**
    * @brief Construct a new adc object
    *
    * @param p_adc_value - percent value for adc
    */
-  adc(embed::percent p_adc_value)
+  adc(hal::percent p_adc_value)
     : m_adc_value(p_adc_value){};
   /**
    * @brief Set the mock adc to a given value
    *
    * @param p_adc_value - percent value to set adc to
    */
-  void set(embed::percent p_adc_value)
+  void set(hal::percent p_adc_value)
   {
     m_adc_value = p_adc_value;
   }
@@ -34,7 +34,7 @@ private:
     return m_adc_value;
   }
 
-  embed::percent m_adc_value = embed::percent::from_ratio(0, 1);
+  hal::percent m_adc_value = hal::percent::from_ratio(0, 1);
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/bit_limits.hpp
+++ b/include/libembeddedhal/bit_limits.hpp
@@ -3,7 +3,7 @@
 #include <concepts>
 #include <cstddef>
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * Available utilities for libembeddedhal
@@ -86,4 +86,4 @@ struct bit_limits
   }
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/can/interface.hpp
+++ b/include/libembeddedhal/can/interface.hpp
@@ -9,7 +9,7 @@
 #include "../error.hpp"
 #include "../frequency.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup can
  * Available Controller Area Network (CAN bus) APIs
@@ -97,4 +97,4 @@ private:
       p_receive_handler) noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/can/network.hpp
+++ b/include/libembeddedhal/can/network.hpp
@@ -7,7 +7,7 @@
 
 #include "interface.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup can
  * @{
@@ -261,4 +261,4 @@ private:
   std::pmr::unordered_map<uint32_t, node_t> m_messages{};
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/config.hpp
+++ b/include/libembeddedhal/config.hpp
@@ -2,33 +2,33 @@
 
 #include <string_view>
 
-namespace embed::config {
+namespace hal::config {
 namespace defaults {
 constexpr std::string_view platform = "test";
 constexpr bool on_error_callback_enabled = false;
 constexpr auto on_error_callback = []() {};
 }  // namespace defaults
 using namespace defaults;
-}  // namespace embed::config
+}  // namespace hal::config
 
 // Pull the tweaks
 #if __has_include(<libembeddedhal.tweaks.hpp>)
 #include <libembeddedhal.tweaks.hpp>
 #endif
 
-namespace embed {
+namespace hal {
 /**
  * @brief Determines if the current application was built for a specific
  * platform. For example:
  *
- *    embed::is_platform("lpc4078");
+ *    hal::is_platform("lpc4078");
  *
  * Will return true if the PLATFORM macro defined at compile time was equal to
  * lpc4078. If the developer wants to be less specific, let say, to just
  * determine if the platform is in the lpc40xx family then the following example
  * will work.
  *
- *    embed::is_platform("lpc40");
+ *    hal::is_platform("lpc40");
  *
  * @param p_platform - platform string pattern to check against
  * @return true - matches the platform string
@@ -51,4 +51,4 @@ namespace embed {
           config::platform.starts_with("unittest") ||
           config::platform.starts_with("test"));
 }
-};  // namespace embed
+};  // namespace hal

--- a/include/libembeddedhal/counter/interface.hpp
+++ b/include/libembeddedhal/counter/interface.hpp
@@ -7,7 +7,7 @@
 #include "../error.hpp"
 #include "../frequency.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup counter
  * Available hardware counter APIs
@@ -33,7 +33,7 @@ public:
   struct uptime_t
   {
     /// Current operating frequency of the counter
-    embed::frequency frequency;
+    hal::frequency frequency;
     /// The current count of the counter
     std::uint32_t count;
   };
@@ -55,4 +55,4 @@ private:
   virtual boost::leaf::result<uptime_t> driver_uptime() noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/counter/mock.hpp
+++ b/include/libembeddedhal/counter/mock.hpp
@@ -4,7 +4,7 @@
 
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup counter
  * @{
@@ -14,7 +14,7 @@ namespace embed::mock {
  * simulations.
  *
  */
-struct counter : public embed::counter
+struct counter : public hal::counter
 {
   /**
    * @brief Queues the uptimes to be returned for uptime()
@@ -41,4 +41,4 @@ private:
   std::queue<uptime_t> m_uptimes{};
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/counter/timeout.hpp
+++ b/include/libembeddedhal/counter/timeout.hpp
@@ -6,15 +6,15 @@
 #include "../units.hpp"
 #include "interface.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup counter
  * @{
  */
 /**
- * @brief Timeout object based on embed::counter
+ * @brief Timeout object based on hal::counter
  *
- * Prefer to use `embed::create_timeout(embed::counter&)` instead of
+ * Prefer to use `hal::create_timeout(hal::counter&)` instead of
  * instantiating this class directly.
  *
  */
@@ -28,10 +28,10 @@ public:
    * @throws std::errc::result_out_of_range if time duration is negative
    */
   static boost::leaf::result<counter_timeout> create(
-    embed::counter& p_counter,
-    embed::time_duration p_duration)
+    hal::counter& p_counter,
+    hal::time_duration p_duration)
   {
-    if (p_duration < embed::time_duration(0)) {
+    if (p_duration < hal::time_duration(0)) {
       return boost::leaf::new_error(std::errc::result_out_of_range);
     }
 
@@ -98,16 +98,16 @@ private:
    * @param p_counter - counter driver
    * @param p_cycles_until_timeout - number of cycles until timeout
    */
-  counter_timeout(embed::counter& p_counter,
+  counter_timeout(hal::counter& p_counter,
                   std::int64_t p_cycles_until_timeout) noexcept
     : m_counter(&p_counter)
     , m_cycles_until_timeout(p_cycles_until_timeout)
   {
   }
 
-  embed::counter* m_counter;
+  hal::counter* m_counter;
   std::int64_t m_cycles_until_timeout = 0;
   std::uint32_t m_previous_count = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/counter/uptime_counter.hpp
+++ b/include/libembeddedhal/counter/uptime_counter.hpp
@@ -2,7 +2,7 @@
 
 #include "interface.hpp"
 
-namespace embed::experimental {
+namespace hal::experimental {
 /**
  * @addtogroup counter
  * @{
@@ -53,9 +53,9 @@ public:
   }
 
 private:
-  embed::counter_interface* m_counter = nullptr;
+  hal::counter_interface* m_counter = nullptr;
   uint32_t m_previous_count{};
   std::chrono::nanoseconds m_last_uptime{};
 };
 /** @} */
-}  // namespace embed::experimental
+}  // namespace hal::experimental

--- a/include/libembeddedhal/counter/util.hpp
+++ b/include/libembeddedhal/counter/util.hpp
@@ -9,26 +9,26 @@
 #include "interface.hpp"
 #include "timeout.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup counter
  * @{
  */
 /**
- * @brief Create a timeout object based on embed::counter.
+ * @brief Create a timeout object based on hal::counter.
  *
  * NOTE: that multiple timeout objects can be made from a single counter without
  * any influence on other timeout objects.
  *
- * @param p_counter - embed::counter implementation
+ * @param p_counter - hal::counter implementation
  * @param p_duration - amount of time until timeout
- * @return boost::leaf::result<embed::counter_timeout>
+ * @return boost::leaf::result<hal::counter_timeout>
  */
-inline boost::leaf::result<embed::counter_timeout> create_timeout(
-  embed::counter& p_counter,
-  embed::time_duration p_duration)
+inline boost::leaf::result<hal::counter_timeout> create_timeout(
+  hal::counter& p_counter,
+  hal::time_duration p_duration)
 {
-  return embed::counter_timeout::create(p_counter, p_duration);
+  return hal::counter_timeout::create(p_counter, p_duration);
 }
 
 /**
@@ -37,19 +37,19 @@ inline boost::leaf::result<embed::counter_timeout> create_timeout(
  * @param p_counter - counter driver
  * @param p_duration - the amount of time to delay for, must be positive
  * @return boost::leaf::result<void> - returns any errors that result from
- * embed::counter::uptime(), otherwise returns success.
+ * hal::counter::uptime(), otherwise returns success.
  * @throws std::errc::result_out_of_range - if the calculated cycle count
  * exceeds std::int64_t.
  */
 [[nodiscard]] inline boost::leaf::result<void> delay(
-  embed::counter& p_counter,
-  embed::time_duration p_duration) noexcept
+  hal::counter& p_counter,
+  hal::time_duration p_duration) noexcept
 {
-  if (p_duration < embed::time_duration(0)) {
+  if (p_duration < hal::time_duration(0)) {
     return boost::leaf::new_error(std::errc::result_out_of_range);
   }
   auto timeout_object = BOOST_LEAF_CHECK(create_timeout(p_counter, p_duration));
   return delay(timeout_object);
 }
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/dac/interface.hpp
+++ b/include/libembeddedhal/dac/interface.hpp
@@ -5,7 +5,7 @@
 #include "../error.hpp"
 #include "../percent.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup dac
  * Available Digital to Analog Converter (DAC) APIs
@@ -41,4 +41,4 @@ private:
   virtual boost::leaf::result<void> driver_write(percent p_value) noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/dac/mock.hpp
+++ b/include/libembeddedhal/dac/mock.hpp
@@ -3,7 +3,7 @@
 #include "../testing.hpp"
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup dac
  * @{
@@ -13,7 +13,7 @@ namespace embed::mock {
  * spy function for write()
  *
  */
-struct dac : public embed::dac
+struct dac : public hal::dac
 {
   /**
    * @brief Reset spy information for write()
@@ -24,7 +24,7 @@ struct dac : public embed::dac
     spy_write.reset();
   }
 
-  /// Spy handler for embed::dac::write()
+  /// Spy handler for hal::dac::write()
   spy_handler<percent> spy_write;
 
 private:
@@ -34,4 +34,4 @@ private:
   };
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/enum.hpp
+++ b/include/libembeddedhal/enum.hpp
@@ -2,7 +2,7 @@
 
 #include <type_traits>
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -30,4 +30,4 @@ concept enumeration = std::is_enum_v<T>;
     p_enum_value);
 }
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/error.hpp
+++ b/include/libembeddedhal/error.hpp
@@ -5,7 +5,7 @@
 #include "config.hpp"
 #include "internal/third_party/leaf.hpp"
 
-namespace embed {
+namespace hal {
 
 template<class T>
 using result = boost::leaf::result<T>;
@@ -56,4 +56,4 @@ struct invalid_option_t : std::false_type
 template<auto... options>
 inline constexpr bool invalid_option = invalid_option_t<options...>::value;
 }  // namespace error
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/experimental/accelerometer/interface.hpp
+++ b/include/libembeddedhal/experimental/accelerometer/interface.hpp
@@ -6,7 +6,7 @@
 #include "../percent.hpp"
 #include "unit.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @brief Accelerometer hardware abstraction interface.
  *
@@ -40,10 +40,10 @@ public:
   /**
    * @brief Representation of a sample of accelerometer data
    *
-   * embed::percent was chosen for representing the x, y, and z data of an
+   * hal::percent was chosen for representing the x, y, and z data of an
    * accelerometer because conversion from N-bit register to percent is fast
    * compared to the math required to convert it to
-   * embed::nanometer_per_second_sq. This means that multiple samples can be
+   * hal::nanometer_per_second_sq. This means that multiple samples can be
    * gathered quickly to be converted to data at a later time.
    *
    */
@@ -59,7 +59,7 @@ public:
     /// driver changes the full_scale between samples. This is uncommon and many
     /// applications will simply save the full scale once and drop saving it for
     /// subsequent calls.
-    embed::microgravity full_scale;
+    hal::microgravity full_scale;
     /// Acceleration in the XYZ axis
     axis_t axis;
     /**
@@ -84,4 +84,4 @@ public:
 private:
   virtual boost::leaf::result<sample> driver_read() noexcept = 0;
 };
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/experimental/accelerometer/mock.hpp
+++ b/include/libembeddedhal/experimental/accelerometer/mock.hpp
@@ -4,13 +4,13 @@
 
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @brief mock accelerometer implementation for use in unit tests and
  * simulations.
  *
  */
-struct accelerometer : public embed::accelerometer
+struct accelerometer : public hal::accelerometer
 {
   /**
    * @brief Queues the samples to be returned for read()
@@ -36,4 +36,4 @@ private:
 
   std::queue<sample> m_samples{};
 };
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/experimental/accelerometer/unit.hpp
+++ b/include/libembeddedhal/experimental/accelerometer/unit.hpp
@@ -2,6 +2,6 @@
 
 #include <cstdint>
 
-namespace embed {
+namespace hal {
 using microgravity = std::int32_t;
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/experimental/linear_encoder/interface.hpp
+++ b/include/libembeddedhal/experimental/linear_encoder/interface.hpp
@@ -3,7 +3,7 @@
 #include "../error.hpp"
 #include "unit.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @brief Hardware abstraction interface for devices that report
  * position of a linear encoder.
@@ -32,4 +32,4 @@ public:
 private:
   virtual boost::leaf::result<length> driver_read() noexcept = 0;
 };
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/experimental/linear_encoder/linear_potentiometer.hpp
+++ b/include/libembeddedhal/experimental/linear_encoder/linear_potentiometer.hpp
@@ -3,9 +3,9 @@
 #include "../adc/interface.hpp"
 #include "../math.hpp"
 
-namespace embed {
+namespace hal {
 /**
- * @brief Linear potentiometer driver that takes an embed::adc and a
+ * @brief Linear potentiometer driver that takes an hal::adc and a
  * settings struct, and reads the distance the linear potentiometer has traveled
  * in micrometer.
  *
@@ -28,9 +28,9 @@ public:
     /// Maximum travel distance in micrometer
     micrometer p_max_distance = 0;
     /// Minimum percent that can be read from ADC
-    embed::percent p_min_adc_output = embed::percent::from_ratio(0, 1);
+    hal::percent p_min_adc_output = hal::percent::from_ratio(0, 1);
     /// Maximum percent that can be read from ADC
-    embed::percent p_max_adc_output = embed::percent::from_ratio(1, 1);
+    hal::percent p_max_adc_output = hal::percent::from_ratio(1, 1);
   };
 
   /**
@@ -39,7 +39,7 @@ public:
    * @param p_adc ADC of linear potentiometer.
    * @param p_settings Settings for linear potentiometer.
    */
-  linear_potentiometer(embed::adc& p_adc, settings p_settings)
+  linear_potentiometer(hal::adc& p_adc, settings p_settings)
     : m_adc(&p_adc)
     , m_settings(p_settings)
   {
@@ -62,7 +62,7 @@ public:
   }
 
 private:
-  embed::adc* m_adc = nullptr;
+  hal::adc* m_adc = nullptr;
   settings m_settings{};
 };
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/experimental/linear_encoder/unit.hpp
+++ b/include/libembeddedhal/experimental/linear_encoder/unit.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace embed {
+namespace hal {
 /// Universal unit for length
 using micrometer = std::int32_t;
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/experimental/rotary_encoder/interface.hpp
+++ b/include/libembeddedhal/experimental/rotary_encoder/interface.hpp
@@ -3,7 +3,7 @@
 #include "../error.hpp"
 #include "unit.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @brief Hardware abstraction interface for devices that report rotational
  * position of an actuator, knob, or some other system.
@@ -39,4 +39,4 @@ public:
 private:
   virtual boost::leaf::result<microrotation> driver_read() noexcept = 0;
 };
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/experimental/rotary_encoder/unit.hpp
+++ b/include/libembeddedhal/experimental/rotary_encoder/unit.hpp
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace embed {
+namespace hal {
 /// Universal unit for angular position
 using microrotation = std::int32_t;
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/experimental/temperature/interface.hpp
+++ b/include/libembeddedhal/experimental/temperature/interface.hpp
@@ -5,7 +5,7 @@
 #include "../error.hpp"
 #include "unit.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @brief Hardware abstraction interface for temperature sensing devices.
  *
@@ -27,4 +27,4 @@ public:
 private:
   virtual boost::leaf::result<microkelvin> driver_read() noexcept = 0;
 };
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/experimental/temperature/mock.hpp
+++ b/include/libembeddedhal/experimental/temperature/mock.hpp
@@ -4,13 +4,13 @@
 
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @brief Mock temperature sensor implementation for use in unit tests and
  * simulations.
  *
  */
-struct temperature_sensor : public embed::temperature_sensor
+struct temperature_sensor : public hal::temperature_sensor
 {
   /**
    * @brief Queues the temperature values to be returned for read()
@@ -36,4 +36,4 @@ private:
 
   std::queue<microkelvin> m_temperatures{};
 };
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/experimental/temperature/unit.hpp
+++ b/include/libembeddedhal/experimental/temperature/unit.hpp
@@ -2,7 +2,7 @@
 
 #include <cstdio>
 
-namespace embed {
+namespace hal {
 /// Universal unit for temperature
 using microkelvin = std::int32_t;
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/frequency.hpp
+++ b/include/libembeddedhal/frequency.hpp
@@ -12,7 +12,7 @@
 #include "percent.hpp"
 #include "units.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -170,7 +170,7 @@ template<std::unsigned_integral Integer>
  */
 [[nodiscard]] constexpr std::int64_t cycles_per(
   const frequency& p_source,
-  embed::time_duration p_duration) noexcept
+  hal::time_duration p_duration) noexcept
 {
   // Full Equation:
   // =========================================================================
@@ -279,7 +279,7 @@ constexpr std::chrono::duration<int64_t, Period> wavelength(
  */
 [[nodiscard]] inline boost::leaf::result<duty_cycle> calculate_duty_cycle(
   const frequency& p_source_clock,
-  embed::time_duration p_duration,
+  hal::time_duration p_duration,
   percent p_percent) noexcept
 {
   std::uint64_t cycles = cycles_per(p_source_clock, p_duration);
@@ -404,4 +404,4 @@ namespace literals {
 }
 }  // namespace literals
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/i2c/interface.hpp
+++ b/include/libembeddedhal/i2c/interface.hpp
@@ -12,7 +12,7 @@
 #include "../frequency.hpp"
 #include "../timeout.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup i2c
  * Available Inter-integrated Circuit (I2C) APIs
@@ -99,7 +99,7 @@ public:
     std::byte p_address,
     std::span<const std::byte> p_data_out,
     std::span<std::byte> p_data_in,
-    std::function<embed::timeout> p_timeout) noexcept
+    std::function<hal::timeout> p_timeout) noexcept
   {
     return driver_transaction(p_address, p_data_out, p_data_in, p_timeout);
   }
@@ -111,7 +111,7 @@ private:
     std::byte p_address,
     std::span<const std::byte> p_data_out,
     std::span<std::byte> p_data_in,
-    std::function<embed::timeout> p_timeout) noexcept = 0;
+    std::function<hal::timeout> p_timeout) noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/i2c/util.hpp
+++ b/include/libembeddedhal/i2c/util.hpp
@@ -8,7 +8,7 @@
 #include "../error.hpp"
 #include "interface.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup i2c
  * @{
@@ -28,7 +28,7 @@ namespace embed {
   i2c& p_i2c,
   std::byte p_address,
   std::span<const std::byte> p_data_out,
-  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
+  std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
   return p_i2c.transaction(
     p_address, p_data_out, std::span<std::byte>{}, p_timeout);
@@ -48,7 +48,7 @@ namespace embed {
   i2c& p_i2c,
   std::byte p_address,
   std::span<std::byte> p_data_in,
-  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
+  std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
   return p_i2c.transaction(
     p_address, std::span<std::byte>{}, p_data_in, p_timeout);
@@ -69,7 +69,7 @@ template<size_t BytesToRead>
 [[nodiscard]] boost::leaf::result<std::array<std::byte, BytesToRead>> read(
   i2c& p_i2c,
   std::byte p_address,
-  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
+  std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
   std::array<std::byte, BytesToRead> buffer;
   BOOST_LEAF_CHECK(read(p_i2c, p_address, buffer, p_timeout));
@@ -94,7 +94,7 @@ template<size_t BytesToRead>
   std::byte p_address,
   std::span<const std::byte> p_data_out,
   std::span<std::byte> p_data_in,
-  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
+  std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
   return p_i2c.transaction(p_address, p_data_out, p_data_in, p_timeout);
 }
@@ -117,7 +117,7 @@ write_then_read(
   i2c& p_i2c,
   std::byte p_address,
   std::span<const std::byte> p_data_out,
-  std::function<embed::timeout> p_timeout = embed::never_timeout()) noexcept
+  std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
   std::array<std::byte, BytesToRead> buffer;
   BOOST_LEAF_CHECK(
@@ -125,4 +125,4 @@ write_then_read(
   return buffer;
 }
 /// @}
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/input_pin/interface.hpp
+++ b/include/libembeddedhal/input_pin/interface.hpp
@@ -3,7 +3,7 @@
 #include "../error.hpp"
 #include "pin_resistors.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup input_pin Input Pin
  * Available digital input pin APIs
@@ -63,4 +63,4 @@ private:
   virtual boost::leaf::result<bool> driver_level() noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/input_pin/mock.hpp
+++ b/include/libembeddedhal/input_pin/mock.hpp
@@ -6,7 +6,7 @@
 #include "../testing.hpp"
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup input_pin Input Pin
  * @{
@@ -15,7 +15,7 @@ namespace embed::mock {
  * @brief mock input_pin implementation for use in unit tests and simulations.
  *
  */
-struct input_pin : public embed::input_pin
+struct input_pin : public hal::input_pin
 {
   /**
    * @brief Reset spy information for configure()
@@ -61,4 +61,4 @@ private:
   std::queue<bool> m_levels{};
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/input_pin/pin_resistors.hpp
+++ b/include/libembeddedhal/input_pin/pin_resistors.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup input_pin Input Pin
  * @{
@@ -26,4 +26,4 @@ enum class pin_resistor
   pull_up,
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/interrupt_pin/interface.hpp
+++ b/include/libembeddedhal/interrupt_pin/interface.hpp
@@ -5,7 +5,7 @@
 #include "../error.hpp"
 #include "../input_pin/pin_resistors.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup interrupt_pin Interrupt Pin
  * Available digital interrupt pin APIs
@@ -104,4 +104,4 @@ private:
   virtual boost::leaf::result<void> driver_detach_interrupt() noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/interrupt_pin/mock.hpp
+++ b/include/libembeddedhal/interrupt_pin/mock.hpp
@@ -6,7 +6,7 @@
 #include "../testing.hpp"
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup interrupt_pin Interrupt Pin
  * @{
@@ -16,7 +16,7 @@ namespace embed::mock {
  * simulations.
  *
  */
-struct interrupt_pin : public embed::interrupt_pin
+struct interrupt_pin : public hal::interrupt_pin
 {
   /**
    * @brief Reset spy information for configure(), attach_interrupt(), and
@@ -39,11 +39,11 @@ struct interrupt_pin : public embed::interrupt_pin
     m_levels = p_levels;
   }
 
-  /// Spy handler for embed::interrupt_pin::configure()
+  /// Spy handler for hal::interrupt_pin::configure()
   spy_handler<settings> spy_configure;
-  /// Spy handler for embed::interrupt_pin::attach_interrupt()
+  /// Spy handler for hal::interrupt_pin::attach_interrupt()
   spy_handler<std::function<void(void)>, trigger_edge> spy_attach_interrupt;
-  /// Spy handler for embed::interrupt_pin::detach_interrupt()
+  /// Spy handler for hal::interrupt_pin::detach_interrupt()
   spy_handler<bool> spy_detach_interrupt;
 
 private:
@@ -76,4 +76,4 @@ private:
   std::queue<bool> m_levels{};
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/map.hpp
+++ b/include/libembeddedhal/map.hpp
@@ -5,7 +5,7 @@
 #include "math.hpp"
 #include "percent.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -43,7 +43,7 @@ struct map_range
    */
   auto distance()
   {
-    return embed::distance(x, y);
+    return hal::distance(x, y);
   }
 };
 
@@ -121,7 +121,7 @@ template<typename T>
   auto slope_remainder = output_distance % input_distance;
 
   // Operation is well defined for integers 32-bit and below
-  auto decimal = embed::percent::from_ratio(slope_remainder, input_distance);
+  auto decimal = hal::percent::from_ratio(slope_remainder, input_distance);
 
   // p_target has already been bounds checked and shown to be within the bounds
   // of p_input_range, thus this subtracts operation will never yield an
@@ -132,7 +132,7 @@ template<typename T>
   // confined to the integral type T times the zero aligned target value will
   // never exceed the bounds of T.
   auto quotient_scaled_value = slope_quotient * align_target_to_zero;
-  // Multiplication between embed::percent & a 32-bit number is always a safe
+  // Multiplication between hal::percent & a 32-bit number is always a safe
   // operation.
   auto remainder_scaled_value = decimal * align_target_to_zero;
 
@@ -146,4 +146,4 @@ template<typename T>
   return scaled_value_with_offset;
 }
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/math.hpp
+++ b/include/libembeddedhal/math.hpp
@@ -7,7 +7,7 @@
 
 #include "error.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -172,4 +172,4 @@ template<std::integral T>
   }
 }
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/motor/interface.hpp
+++ b/include/libembeddedhal/motor/interface.hpp
@@ -3,7 +3,7 @@
 #include "../error.hpp"
 #include "../percent.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup motor
  * Available motor APIs
@@ -63,4 +63,4 @@ private:
   virtual boost::leaf::result<void> driver_power(percent p_power) noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/motor/mock.hpp
+++ b/include/libembeddedhal/motor/mock.hpp
@@ -3,7 +3,7 @@
 #include "../testing.hpp"
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup motor
  * @{
@@ -13,7 +13,7 @@ namespace embed::mock {
  * spy function for power()
  *
  */
-struct motor : public embed::motor
+struct motor : public hal::motor
 {
   /**
    * @brief Reset spy information for power()
@@ -24,7 +24,7 @@ struct motor : public embed::motor
     spy_power.reset();
   }
 
-  /// Spy handler for embed::motor::write()
+  /// Spy handler for hal::motor::write()
   spy_handler<percent> spy_power;
 
 private:
@@ -34,4 +34,4 @@ private:
   };
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/output_pin/interface.hpp
+++ b/include/libembeddedhal/output_pin/interface.hpp
@@ -3,7 +3,7 @@
 #include "../error.hpp"
 #include "../input_pin/pin_resistors.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup output_pin Output Pin
  * Available output pin APIs
@@ -85,4 +85,4 @@ private:
   virtual boost::leaf::result<bool> driver_level() noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/output_pin/mock.hpp
+++ b/include/libembeddedhal/output_pin/mock.hpp
@@ -3,7 +3,7 @@
 #include "../testing.hpp"
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup output_pin Output Pin
  * @{
@@ -12,7 +12,7 @@ namespace embed::mock {
  * @brief mock output pin for use in unit tests and simulations
  *
  */
-struct output_pin : public embed::output_pin
+struct output_pin : public hal::output_pin
 {
   /**
    * @brief Reset spy information for configure() and level()
@@ -24,9 +24,9 @@ struct output_pin : public embed::output_pin
     spy_level.reset();
   }
 
-  /// Spy handler for embed::output_pin::configure()
+  /// Spy handler for hal::output_pin::configure()
   spy_handler<settings> spy_configure;
-  /// Spy handler for embed::output_pin::level()
+  /// Spy handler for hal::output_pin::level()
   spy_handler<bool> spy_level;
 
 private:
@@ -47,4 +47,4 @@ private:
   bool m_current_level = false;
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/overflow_counter.hpp
+++ b/include/libembeddedhal/overflow_counter.hpp
@@ -2,7 +2,7 @@
 
 #include "bit_limits.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -77,4 +77,4 @@ private:
   uint32_t m_overflow_count = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/percent.hpp
+++ b/include/libembeddedhal/percent.hpp
@@ -13,7 +13,7 @@
 #include "math.hpp"
 #include "to_array.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -202,11 +202,11 @@ public:
    *
    * Examples:
    *
-   *    To generate 50%, use embed::percent::from_ratio(1, 2);
-   *    To generate 50%, use embed::percent::from_ratio(50, 100);
-   *    To generate 50%, use embed::percent::from_ratio(250, 500);
-   *    To generate 20%, use embed::percent::from_ratio(20, 100);
-   *    To generate 14%, use embed::percent::from_ratio(35, 250);
+   *    To generate 50%, use hal::percent::from_ratio(1, 2);
+   *    To generate 50%, use hal::percent::from_ratio(50, 100);
+   *    To generate 50%, use hal::percent::from_ratio(250, 500);
+   *    To generate 20%, use hal::percent::from_ratio(20, 100);
+   *    To generate 14%, use hal::percent::from_ratio(35, 250);
    *
    * @tparam T - integral types for the numerator and denominator
    * @param p_progress - the number in which a percentage will be generated
@@ -585,4 +585,4 @@ private:
 }
 
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/percentage.hpp
+++ b/include/libembeddedhal/percentage.hpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <concepts>
 
-namespace embed {
+namespace hal {
 /**
  * @brief A type representing a percentage value
  *
@@ -69,4 +69,4 @@ private:
   }
   float_t m_value{ 0.0 };
 };
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/pwm/interface.hpp
+++ b/include/libembeddedhal/pwm/interface.hpp
@@ -6,7 +6,7 @@
 #include "../frequency.hpp"
 #include "../percent.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup pwm
  * Available pwm APIs
@@ -24,7 +24,7 @@ public:
   struct settings
   {
     /// The target channel PWM frequency.
-    embed::frequency frequency = embed::frequency(1'000);
+    hal::frequency frequency = hal::frequency(1'000);
 
     /**
      * @brief Default operators for <, <=, >, >= and ==
@@ -68,4 +68,4 @@ private:
     percent p_duty_cycle) noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/pwm/mock.hpp
+++ b/include/libembeddedhal/pwm/mock.hpp
@@ -3,7 +3,7 @@
 #include "../testing.hpp"
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup pwm
  * @{
@@ -13,7 +13,7 @@ namespace embed::mock {
  * functions for configure() and duty_cycle().
  *
  */
-struct pwm : public embed::pwm
+struct pwm : public hal::pwm
 {
   /**
    * @brief Reset spy information for both configure() and duty_cycle()
@@ -25,9 +25,9 @@ struct pwm : public embed::pwm
     spy_duty_cycle.reset();
   }
 
-  /// Spy handler for embed::pwm::configure()
+  /// Spy handler for hal::pwm::configure()
   spy_handler<settings> spy_configure;
-  /// Spy handler for embed::pwm::duty_cycle()
+  /// Spy handler for hal::pwm::duty_cycle()
   spy_handler<percent> spy_duty_cycle;
 
 private:
@@ -43,4 +43,4 @@ private:
   };
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/serial/interface.hpp
+++ b/include/libembeddedhal/serial/interface.hpp
@@ -7,7 +7,7 @@
 #include <optional>
 #include <span>
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup serial
  * Available serial APIs
@@ -160,4 +160,4 @@ private:
   virtual boost::leaf::result<void> driver_flush() noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/serial/util.hpp
+++ b/include/libembeddedhal/serial/util.hpp
@@ -7,7 +7,7 @@
 #include "../error.hpp"
 #include "interface.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup serial
  * @{
@@ -136,4 +136,4 @@ write_then_read(serial& p_serial,
   return buffer;
 }
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/servo/interface.hpp
+++ b/include/libembeddedhal/servo/interface.hpp
@@ -3,7 +3,7 @@
 #include "../error.hpp"
 #include "../percent.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup servo
  * Available servo APIs
@@ -69,21 +69,21 @@ public:
    *
    *     // This is a made up servo has 180 degrees of movement and has absolute
    *     // positioning.
-   *     embed::example_servo servo;  // implements embed::servo
+   *     hal::example_servo servo;  // implements hal::servo
    *     // Move to center position
-   *     servo.position(embed::percent::from_ratio(0, 90));
+   *     servo.position(hal::percent::from_ratio(0, 90));
    *     // ... delay ...
    *     // Move to the +45 degrees position
-   *     servo.position(embed::percent::from_ratio(45, 90));
+   *     servo.position(hal::percent::from_ratio(45, 90));
    *     // ... delay ...
    *     // Move to the -45 degrees position
-   *     servo.position(embed::percent::from_ratio(-45, 90));
+   *     servo.position(hal::percent::from_ratio(-45, 90));
    *     // ... delay ...
    *     // Move to the -90 degrees position
-   *     servo.position(embed::percent::from_ratio(-90, 90));
+   *     servo.position(hal::percent::from_ratio(-90, 90));
    *     // ... delay ...
    *     // Move to the +90 degrees position
-   *     servo.position(embed::percent::from_ratio(90, 90));
+   *     servo.position(hal::percent::from_ratio(90, 90));
    *
    * @param p_position - position to move the servo to
    * @return boost::leaf::result<void> - success or error flag
@@ -98,4 +98,4 @@ private:
     percent p_position) noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/servo/mock.hpp
+++ b/include/libembeddedhal/servo/mock.hpp
@@ -3,7 +3,7 @@
 #include "../testing.hpp"
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup servo
  * @{
@@ -13,7 +13,7 @@ namespace embed::mock {
  * simulations.
  *
  */
-struct servo : public embed::servo
+struct servo : public hal::servo
 {
   /**
    * @brief Reset spy information for position()
@@ -24,8 +24,8 @@ struct servo : public embed::servo
     spy_position.reset();
   }
 
-  /// Spy handler for embed::servo::position()
-  spy_handler<embed::percent> spy_position;
+  /// Spy handler for hal::servo::position()
+  spy_handler<hal::percent> spy_position;
 
 private:
   boost::leaf::result<void> driver_position(
@@ -35,4 +35,4 @@ private:
   }
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/servo/rc.hpp
+++ b/include/libembeddedhal/servo/rc.hpp
@@ -5,7 +5,7 @@
 #include "../pwm/interface.hpp"
 #include "interface.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup servo
  * @{
@@ -14,7 +14,7 @@ namespace embed {
  * @brief Generic RC servo driver.
  *
  */
-class rc_servo : public embed::servo
+class rc_servo : public hal::servo
 {
 public:
   /**
@@ -33,7 +33,7 @@ public:
   template<uint32_t Frequency = 50,
            uint32_t MinMicroseconds = 1000,
            uint32_t MaxMicroseconds = 2000>
-  static boost::leaf::result<rc_servo> create(embed::pwm& p_pwm)
+  static boost::leaf::result<rc_servo> create(hal::pwm& p_pwm)
   {
     // Check that MinMicroseconds is less than MaxMicroseconds
     static_assert(
@@ -43,8 +43,8 @@ public:
     static_assert(
       (1000.0 / Frequency) > (MaxMicroseconds / 1000.0),
       "The maximum microseconds is greater than the period of the frequency");
-    constexpr embed::frequency frequency = embed::frequency{ Frequency };
-    constexpr embed::pwm::settings settings{ .frequency = frequency };
+    constexpr hal::frequency frequency = hal::frequency{ Frequency };
+    constexpr hal::pwm::settings settings{ .frequency = frequency };
     BOOST_LEAF_CHECK(p_pwm.configure(settings));
 
     auto frequency_wavelength =
@@ -57,7 +57,7 @@ public:
   }
 
 private:
-  constexpr rc_servo(embed::pwm& p_pwm,
+  constexpr rc_servo(hal::pwm& p_pwm,
                      frequency p_frequency,
                      percent p_min_percent,
                      percent p_max_percent)
@@ -81,10 +81,10 @@ private:
     return m_pwm->duty_cycle(scaled_percent);
   }
 
-  embed::pwm* m_pwm;
-  embed::frequency m_frequency = frequency(50);
+  hal::pwm* m_pwm;
+  hal::frequency m_frequency = frequency(50);
   percent m_min_percent = percent::from_ratio(1, 10);
   percent m_max_percent = percent::from_ratio(2, 10);
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/spi/interface.hpp
+++ b/include/libembeddedhal/spi/interface.hpp
@@ -7,7 +7,7 @@
 #include "../error.hpp"
 #include "../frequency.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup spi
  * Available spi APIs
@@ -91,4 +91,4 @@ private:
     std::byte p_filler) noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/spi/mock.hpp
+++ b/include/libembeddedhal/spi/mock.hpp
@@ -3,7 +3,7 @@
 #include "../testing.hpp"
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup spi
  * @{
@@ -14,7 +14,7 @@ namespace embed::mock {
  * record ignores the in buffer and just stores the data being sent so it can be
  * inspected later.
  */
-struct write_only_spi : public embed::spi
+struct write_only_spi : public hal::spi
 {
   /**
    * @brief Reset spy information for both configure() and transfer()
@@ -26,9 +26,9 @@ struct write_only_spi : public embed::spi
     write_record.clear();
   }
 
-  /// Spy handler for embed::spi::configure()
+  /// Spy handler for hal::spi::configure()
   spy_handler<settings> spy_configure;
-  /// Record of the out data from embed::spi::transfer()
+  /// Record of the out data from hal::spi::transfer()
   std::vector<std::vector<std::byte>> write_record;
 
 private:
@@ -47,4 +47,4 @@ private:
   };
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/spi/util.hpp
+++ b/include/libembeddedhal/spi/util.hpp
@@ -5,7 +5,7 @@
 #include "../error.hpp"
 #include "interface.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup spi
  * @{
@@ -118,4 +118,4 @@ write_then_read(spi& p_spi,
   return read<BytesToRead>(p_spi, p_filler);
 }
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/static_callable.hpp
+++ b/include/libembeddedhal/static_callable.hpp
@@ -2,7 +2,7 @@
 
 #include <functional>
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -81,4 +81,4 @@ private:
   inline static std::function<return_t(args_t... p_args)> callback;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/static_memory_resource.hpp
+++ b/include/libembeddedhal/static_memory_resource.hpp
@@ -3,7 +3,7 @@
 #include <cstddef>
 #include <memory_resource>
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -124,4 +124,4 @@ private:
   std::pmr::monotonic_buffer_resource m_resource{};
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/testing.hpp
+++ b/include/libembeddedhal/testing.hpp
@@ -3,7 +3,7 @@
 #include <tuple>
 #include <vector>
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup testing
  * @{
@@ -86,4 +86,4 @@ private:
   int m_error_trigger = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/timeout.hpp
+++ b/include/libembeddedhal/timeout.hpp
@@ -1,6 +1,6 @@
 /**
  * @file timeout.hpp
- * @brief Provides the embed::timeout type and utility functions that use that
+ * @brief Provides the hal::timeout type and utility functions that use that
  * type.
  *
  */
@@ -11,7 +11,7 @@
 
 #include "error.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -21,7 +21,7 @@ namespace embed {
  * that the procedure has exceeded its time allotment and should return control
  * to the calling function.
  *
- * @throws embed::timeout - when the timeout condition has been met.
+ * @throws hal::timeout - when the timeout condition has been met.
  * @returns boost::leaf::result<void> - sets error flag set when timeout
  * condition has been met, otherwise returns success.
  */
@@ -35,7 +35,7 @@ using timeout = boost::leaf::result<void>(void);
  * @param p_timeout - callable timeout object
  * @return boost::leaf::result<void> - success
  */
-template<typename Timeout = std::function<embed::timeout>>
+template<typename Timeout = std::function<hal::timeout>>
 [[nodiscard]] inline boost::leaf::result<void> delay(Timeout p_timeout) noexcept
 {
   bool waiting = true;
@@ -70,4 +70,4 @@ template<typename Timeout = std::function<embed::timeout>>
   return []() -> boost::leaf::result<void> { return {}; };
 }
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/timer/interface.hpp
+++ b/include/libembeddedhal/timer/interface.hpp
@@ -5,7 +5,7 @@
 
 #include "../error.hpp"
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup timer
  * Available timer APIs
@@ -107,4 +107,4 @@ private:
     std::chrono::nanoseconds p_delay) noexcept = 0;
 };
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/timer/mock.hpp
+++ b/include/libembeddedhal/timer/mock.hpp
@@ -3,7 +3,7 @@
 #include "../testing.hpp"
 #include "interface.hpp"
 
-namespace embed::mock {
+namespace hal::mock {
 /**
  * @addtogroup timer
  * @{
@@ -13,7 +13,7 @@ namespace embed::mock {
  * spy functions for schedule(), clear(), and is_running()
  *
  */
-struct timer : public embed::timer
+struct timer : public hal::timer
 {
   /**
    * @brief Reset spy information for schedule(), clear(), and is_running()
@@ -26,11 +26,11 @@ struct timer : public embed::timer
     spy_is_running.reset();
   }
 
-  /// Spy handler for embed::timer::schedule()
+  /// Spy handler for hal::timer::schedule()
   spy_handler<std::function<void(void)>, std::chrono::nanoseconds> spy_schedule;
-  /// Spy handler for embed::timer::is_running()
+  /// Spy handler for hal::timer::is_running()
   spy_handler<bool> spy_is_running;
-  /// Spy handler for embed::timer::clear()
+  /// Spy handler for hal::timer::clear()
   spy_handler<bool> spy_clear;
 
 private:
@@ -57,4 +57,4 @@ private:
   bool m_is_running = false;
 };
 /** @} */
-}  // namespace embed::mock
+}  // namespace hal::mock

--- a/include/libembeddedhal/to_array.hpp
+++ b/include/libembeddedhal/to_array.hpp
@@ -5,7 +5,7 @@
 #include <cstddef>
 #include <string_view>
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -33,4 +33,4 @@ template<size_t N>
   return result;
 }
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/include/libembeddedhal/units.hpp
+++ b/include/libembeddedhal/units.hpp
@@ -3,7 +3,7 @@
 #include <chrono>
 #include <cstdint>
 
-namespace embed {
+namespace hal {
 /**
  * @addtogroup utility
  * @{
@@ -14,4 +14,4 @@ namespace embed {
 using time_duration = std::chrono::duration<std::int32_t, std::micro>;
 
 /** @} */
-}  // namespace embed
+}  // namespace hal

--- a/tests/adc/mock.test.cpp
+++ b/tests/adc/mock.test.cpp
@@ -1,15 +1,15 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/adc/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite adc_mock_test = []() {
   using namespace boost::ut;
 
   // Setup
-  auto expected1 = embed::percent::from_ratio(1, 4);
-  auto expected2 = embed::percent::from_ratio(1, 2);
-  auto expected3 = embed::percent::from_ratio(1, 1);
-  embed::mock::adc mock(expected1);
+  auto expected1 = hal::percent::from_ratio(1, 4);
+  auto expected2 = hal::percent::from_ratio(1, 2);
+  auto expected3 = hal::percent::from_ratio(1, 1);
+  hal::mock::adc mock(expected1);
 
   // Exercise + Verify
   expect(that % expected1.raw_value() == mock.read().value().raw_value());
@@ -18,4 +18,4 @@ boost::ut::suite adc_mock_test = []() {
   mock.set(expected3);
   expect(that % expected3.raw_value() == mock.read().value().raw_value());
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/counter/mock.test.cpp
+++ b/tests/counter/mock.test.cpp
@@ -3,16 +3,16 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/counter/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite counter_mock_test = []() {
   using namespace boost::ut;
 
-  "embed::mock::counter::uptime()"_test = []() {
+  "hal::mock::counter::uptime()"_test = []() {
     // Setup
-    embed::mock::counter mock;
-    constexpr embed::counter::uptime_t expected1{ frequency{ 1'000'000 }, 0 };
-    embed::counter::uptime_t expected2{ frequency{ 8'000'000 }, 1 };
-    embed::counter::uptime_t expected3{ frequency{ 48'000'000 }, 2 };
+    hal::mock::counter mock;
+    constexpr hal::counter::uptime_t expected1{ frequency{ 1'000'000 }, 0 };
+    hal::counter::uptime_t expected2{ frequency{ 8'000'000 }, 1 };
+    hal::counter::uptime_t expected3{ frequency{ 48'000'000 }, 2 };
     std::deque samples{ expected1, expected2, expected3 };
     std::queue queue(samples);
 
@@ -33,4 +33,4 @@ boost::ut::suite counter_mock_test = []() {
     expect(throws([&mock] { mock.uptime().value(); }));
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/counter/uptime_counter.test.cpp
+++ b/tests/counter/uptime_counter.test.cpp
@@ -2,14 +2,14 @@
 #include <libembeddedhal/counter/uptime_counter.hpp>
 #include <queue>
 
-namespace embed {
+namespace hal {
 
 boost::ut::suite uptime_utility_test = []() {
   using namespace boost::ut;
   using namespace std::literals;
-  using namespace embed::literals;
+  using namespace hal::literals;
 
-  class mock_counter : public embed::counter
+  class mock_counter : public hal::counter
   {
   public:
     boost::leaf::result<uptime_t> driver_uptime() noexcept override
@@ -22,7 +22,7 @@ boost::ut::suite uptime_utility_test = []() {
     std::queue<std::uint32_t> uptime_sequence{};
 
   private:
-    embed::frequency m_frequency{ 1'000_MHz };
+    hal::frequency m_frequency{ 1'000_MHz };
   };
 
   "[uptime_counter] zero"_test = []() {
@@ -145,4 +145,4 @@ boost::ut::suite uptime_utility_test = []() {
     // None at the moment
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/counter/util.test.cpp
+++ b/tests/counter/util.test.cpp
@@ -3,13 +3,13 @@
 
 #include "../ostreams.hpp"
 
-namespace embed {
+namespace hal {
 boost::ut::suite counter_utility_test = []() {
   using namespace boost::ut;
 
   static constexpr frequency expected_frequency{ 1'000'000 };
 
-  class dummy_counter : public embed::counter
+  class dummy_counter : public hal::counter
   {
   public:
     uptime_t get_internal_uptime()
@@ -29,9 +29,9 @@ boost::ut::suite counter_utility_test = []() {
 
   // =============== timeout ===============
 
-  "embed::create_timeout(embed::counter, 0ns)"_test = []() {
+  "hal::create_timeout(hal::counter, 0ns)"_test = []() {
     // Setup
-    static constexpr embed::time_duration expected(0);
+    static constexpr hal::time_duration expected(0);
     dummy_counter test_counter;
     bool success = false;
 
@@ -57,9 +57,9 @@ boost::ut::suite counter_utility_test = []() {
            test_counter.get_internal_uptime().frequency);
   };
 
-  "embed::create_timeout(embed::counter, 50ns)"_test = []() {
+  "hal::create_timeout(hal::counter, 50ns)"_test = []() {
     // Setup
-    static constexpr embed::time_duration expected(50);
+    static constexpr hal::time_duration expected(50);
     dummy_counter test_counter;
     bool success = false;
 
@@ -88,9 +88,9 @@ boost::ut::suite counter_utility_test = []() {
            test_counter.get_internal_uptime().frequency);
   };
 
-  "embed::create_timeout(embed::counter, 1337ns)"_test = []() {
+  "hal::create_timeout(hal::counter, 1337ns)"_test = []() {
     // Setup
-    static constexpr embed::time_duration expected(1337);
+    static constexpr hal::time_duration expected(1337);
     dummy_counter test_counter;
     bool success = false;
 
@@ -119,9 +119,9 @@ boost::ut::suite counter_utility_test = []() {
            test_counter.get_internal_uptime().frequency);
   };
 
-  "embed::create_timeout(embed::counter, -5ns) returns error"_test = []() {
+  "hal::create_timeout(hal::counter, -5ns) returns error"_test = []() {
     // Setup
-    static constexpr embed::time_duration expected(-5);
+    static constexpr hal::time_duration expected(-5);
     dummy_counter test_counter;
 
     // Exercise
@@ -136,9 +136,9 @@ boost::ut::suite counter_utility_test = []() {
 
   // =============== delay ===============
 
-  "embed::delay(embed::counter, 0ns)"_test = []() {
+  "hal::delay(hal::counter, 0ns)"_test = []() {
     // Setup
-    static constexpr embed::time_duration expected(0);
+    static constexpr hal::time_duration expected(0);
     dummy_counter test_counter;
 
     // Exercise
@@ -154,9 +154,9 @@ boost::ut::suite counter_utility_test = []() {
            test_counter.get_internal_uptime().frequency);
   };
 
-  "embed::delay(embed::counter, 50ns)"_test = []() {
+  "hal::delay(hal::counter, 50ns)"_test = []() {
     // Setup
-    static constexpr embed::time_duration expected(50);
+    static constexpr hal::time_duration expected(50);
     dummy_counter test_counter;
 
     // Exercise
@@ -169,9 +169,9 @@ boost::ut::suite counter_utility_test = []() {
            test_counter.get_internal_uptime().frequency);
   };
 
-  "embed::delay(embed::counter, 1337ns)"_test = []() {
+  "hal::delay(hal::counter, 1337ns)"_test = []() {
     // Setup
-    static constexpr embed::time_duration expected(1'337);
+    static constexpr hal::time_duration expected(1'337);
     dummy_counter test_counter;
 
     // Exercise
@@ -184,9 +184,9 @@ boost::ut::suite counter_utility_test = []() {
            test_counter.get_internal_uptime().frequency);
   };
 
-  "embed::delay(embed::counter, -5ns) returns error"_test = []() {
+  "hal::delay(hal::counter, -5ns) returns error"_test = []() {
     // Setup
-    static constexpr embed::time_duration expected(-5);
+    static constexpr hal::time_duration expected(-5);
     dummy_counter test_counter;
 
     // Exercise
@@ -199,4 +199,4 @@ boost::ut::suite counter_utility_test = []() {
            test_counter.get_internal_uptime().frequency);
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/dac/mock.test.cpp
+++ b/tests/dac/mock.test.cpp
@@ -1,12 +1,12 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/dac/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite dac_mock_test = []() {
   using namespace boost::ut;
 
   // Setup
-  embed::mock::dac mock;
+  hal::mock::dac mock;
   constexpr auto expected1 = percent::from_ratio(1, 2);
   constexpr auto expected2 = percent::from_ratio(1, 4);
   mock.spy_write.trigger_error_on_call(3);
@@ -21,4 +21,4 @@ boost::ut::suite dac_mock_test = []() {
   expect(!mock.write(expected2));
   expect(expected2 == std::get<0>(mock.spy_write.call_history().at(2)));
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/error.test.cpp
+++ b/tests/error.test.cpp
@@ -1,11 +1,11 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/error.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite error_test = []() {
   using namespace boost::ut;
 
-  "[success] embed::on_error calls callback"_test = []() {
+  "[success] hal::on_error calls callback"_test = []() {
     // Setup
     auto current_call_count = config::callback_call_count;
     expect(that % current_call_count == config::callback_call_count);
@@ -18,7 +18,7 @@ boost::ut::suite error_test = []() {
     expect(that % current_call_count < config::callback_call_count);
   };
 
-  "[success] embed::attempt calls handler"_test = []() {
+  "[success] hal::attempt calls handler"_test = []() {
     // Setup
     constexpr int expected = 123456789;
     int value_to_be_change = 0;
@@ -37,7 +37,7 @@ boost::ut::suite error_test = []() {
     expect(that % true == bool{ result });
   };
 
-  "[success] embed::attempt calls handler"_test = []() {
+  "[success] hal::attempt calls handler"_test = []() {
     // Setup
     constexpr int expected = 123456789;
     int value_to_be_change = 0;
@@ -54,4 +54,4 @@ boost::ut::suite error_test = []() {
     expect(that % value_to_be_change == expected);
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/experimental/accelerometer/interface.test.cpp
+++ b/tests/experimental/accelerometer/interface.test.cpp
@@ -1,9 +1,9 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/accelerometer/interface.hpp>
 
-namespace embed {
+namespace hal {
 namespace {
-constexpr auto expected_sample = embed::accelerometer::sample{
+constexpr auto expected_sample = hal::accelerometer::sample{
   .full_scale = 1'000'000'000,
   .axis = {
     .x = percent::from_ratio(1, 2),
@@ -12,7 +12,7 @@ constexpr auto expected_sample = embed::accelerometer::sample{
   },
 };
 
-class test_accelerometer : public embed::accelerometer
+class test_accelerometer : public hal::accelerometer
 {
 private:
   boost::leaf::result<sample> driver_read() noexcept override
@@ -33,4 +33,4 @@ boost::ut::suite accelerometer_test = []() {
   // Verify
   expect(expected_sample == sample);
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/experimental/accelerometer/mock.test.cpp
+++ b/tests/experimental/accelerometer/mock.test.cpp
@@ -3,25 +3,25 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/accelerometer/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite accelerometer_mock_test = []() {
   using namespace boost::ut;
 
-  "embed::mock::accelerometer::read()"_test = []() {
+  "hal::mock::accelerometer::read()"_test = []() {
     // Setup
-    embed::mock::accelerometer mock;
-    embed::accelerometer::sample expected1;
-    expected1.axis.x = embed::percent::from_ratio(1, 4);
-    expected1.axis.y = embed::percent::from_ratio(1, 4);
-    expected1.axis.z = embed::percent::from_ratio(1, 4);
-    embed::accelerometer::sample expected2;
-    expected2.axis.x = embed::percent::from_ratio(1, 2);
-    expected2.axis.y = embed::percent::from_ratio(1, 2);
-    expected2.axis.z = embed::percent::from_ratio(1, 2);
-    embed::accelerometer::sample expected3;
-    expected3.axis.x = embed::percent::from_ratio(1, 1);
-    expected3.axis.y = embed::percent::from_ratio(1, 1);
-    expected3.axis.z = embed::percent::from_ratio(1, 1);
+    hal::mock::accelerometer mock;
+    hal::accelerometer::sample expected1;
+    expected1.axis.x = hal::percent::from_ratio(1, 4);
+    expected1.axis.y = hal::percent::from_ratio(1, 4);
+    expected1.axis.z = hal::percent::from_ratio(1, 4);
+    hal::accelerometer::sample expected2;
+    expected2.axis.x = hal::percent::from_ratio(1, 2);
+    expected2.axis.y = hal::percent::from_ratio(1, 2);
+    expected2.axis.z = hal::percent::from_ratio(1, 2);
+    hal::accelerometer::sample expected3;
+    expected3.axis.x = hal::percent::from_ratio(1, 1);
+    expected3.axis.y = hal::percent::from_ratio(1, 1);
+    expected3.axis.z = hal::percent::from_ratio(1, 1);
 
     std::deque samples{ expected1, expected2, expected3 };
     std::queue queue(samples);
@@ -36,4 +36,4 @@ boost::ut::suite accelerometer_mock_test = []() {
     expect(throws([&mock] { mock.read().value(); }));
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/experimental/linear_encoder/interface.test.cpp
+++ b/tests/experimental/linear_encoder/interface.test.cpp
@@ -1,10 +1,10 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/linear_encoder/interface.hpp>
 
-namespace embed {
+namespace hal {
 namespace {
 constexpr auto expected_linear_position = length(1000000);
-class test_linear_encoder : public embed::linear_encoder
+class test_linear_encoder : public hal::linear_encoder
 {
 private:
   boost::leaf::result<length> driver_read() noexcept override
@@ -25,4 +25,4 @@ boost::ut::suite linear_encoder_test = []() {
   // Verify
   expect(expected_linear_position == sample);
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/experimental/linear_encoder/linear_potentiometer.test.cpp
+++ b/tests/experimental/linear_encoder/linear_potentiometer.test.cpp
@@ -2,202 +2,202 @@
 #include <libembeddedhal/adc/mock.hpp>
 #include <libembeddedhal/linear_potentiometer/interface.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite linear_pot_test = []() {
   using namespace boost::ut;
 
-  "embed::linear_potentiometer::read() default settings"_test = []() {
+  "hal::linear_potentiometer::read() default settings"_test = []() {
     // Setup
-    embed::mock::adc mock(embed::percent::from_ratio(1, 2));
-    embed::linear_potentiometer::settings settings;
-    embed::linear_potentiometer test(mock, settings);
+    hal::mock::adc mock(hal::percent::from_ratio(1, 2));
+    hal::linear_potentiometer::settings settings;
+    hal::linear_potentiometer test(mock, settings);
 
     // Exercise + Verify
     expect(that % 0 == test.read().value());
   };
 
-  "embed::linear_potentiometer::read() positive percent range"_test = []() {
+  "hal::linear_potentiometer::read() positive percent range"_test = []() {
     // Setup
-    embed::mock::adc mock(embed::percent::from_ratio(0, 1));
-    embed::linear_potentiometer::settings settings;
+    hal::mock::adc mock(hal::percent::from_ratio(0, 1));
+    hal::linear_potentiometer::settings settings;
     settings.p_min_distance = 1;
     settings.p_max_distance = 100;
-    settings.p_min_adc_output = embed::percent::from_ratio(0, 1);
-    settings.p_max_adc_output = embed::percent::from_ratio(1, 1);
-    embed::linear_potentiometer test(mock, settings);
+    settings.p_min_adc_output = hal::percent::from_ratio(0, 1);
+    settings.p_max_adc_output = hal::percent::from_ratio(1, 1);
+    hal::linear_potentiometer test(mock, settings);
 
     // Exercise + Verify
     expect(that % 1 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 4));
+    mock.set(hal::percent::from_ratio(1, 4));
     expect(that % 26 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 2));
+    mock.set(hal::percent::from_ratio(1, 2));
     expect(that % 51 == test.read().value());
-    mock.set(embed::percent::from_ratio(3, 4));
+    mock.set(hal::percent::from_ratio(3, 4));
     expect(that % 76 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 1));
+    mock.set(hal::percent::from_ratio(1, 1));
     expect(that % 100 == test.read().value());
-    mock.set(embed::percent::from_ratio(2, 1));
+    mock.set(hal::percent::from_ratio(2, 1));
     expect(that % 100 == test.read().value());
-    mock.set(embed::percent::from_ratio(-1, 2));
+    mock.set(hal::percent::from_ratio(-1, 2));
     expect(that % 1 == test.read().value());
   };
 
-  "embed::linear_potentiometer::read() negative percent range"_test = []() {
+  "hal::linear_potentiometer::read() negative percent range"_test = []() {
     // Setup
-    embed::mock::adc mock(embed::percent::from_ratio(-1, 1));
-    embed::linear_potentiometer::settings settings;
+    hal::mock::adc mock(hal::percent::from_ratio(-1, 1));
+    hal::linear_potentiometer::settings settings;
     settings.p_min_distance = 0;
     settings.p_max_distance = 100;
-    settings.p_min_adc_output = embed::percent::from_ratio(-1, 1);
-    settings.p_max_adc_output = embed::percent::from_ratio(0, 1);
-    embed::linear_potentiometer test(mock, settings);
+    settings.p_min_adc_output = hal::percent::from_ratio(-1, 1);
+    settings.p_max_adc_output = hal::percent::from_ratio(0, 1);
+    hal::linear_potentiometer test(mock, settings);
 
     // Exercise + Verify
     expect(that % 0 == test.read().value());
-    mock.set(embed::percent::from_ratio(-1, 4));
+    mock.set(hal::percent::from_ratio(-1, 4));
     expect(that % 75 == test.read().value());
-    mock.set(embed::percent::from_ratio(-1, 2));
+    mock.set(hal::percent::from_ratio(-1, 2));
     expect(that % 50 == test.read().value());
-    mock.set(embed::percent::from_ratio(-3, 4));
+    mock.set(hal::percent::from_ratio(-3, 4));
     expect(that % 25 == test.read().value());
-    mock.set(embed::percent::from_ratio(0, 1));
+    mock.set(hal::percent::from_ratio(0, 1));
     expect(that % 100 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 2));
+    mock.set(hal::percent::from_ratio(1, 2));
     expect(that % 100 == test.read().value());
-    mock.set(embed::percent::from_ratio(-2, 1));
+    mock.set(hal::percent::from_ratio(-2, 1));
     expect(that % 0 == test.read().value());
   };
 
-  "embed::linear_potentiometer::read() negative distances"_test = []() {
+  "hal::linear_potentiometer::read() negative distances"_test = []() {
     // Setup
-    embed::mock::adc mock(embed::percent::from_ratio(0, 1));
-    embed::linear_potentiometer::settings settings;
+    hal::mock::adc mock(hal::percent::from_ratio(0, 1));
+    hal::linear_potentiometer::settings settings;
     settings.p_min_distance = -200;
     settings.p_max_distance = -100;
-    settings.p_min_adc_output = embed::percent::from_ratio(0, 1);
-    settings.p_max_adc_output = embed::percent::from_ratio(1, 1);
-    embed::linear_potentiometer test(mock, settings);
+    settings.p_min_adc_output = hal::percent::from_ratio(0, 1);
+    settings.p_max_adc_output = hal::percent::from_ratio(1, 1);
+    hal::linear_potentiometer test(mock, settings);
 
     // Exercise + Verify
     expect(that % -200 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 4));
+    mock.set(hal::percent::from_ratio(1, 4));
     expect(that % -175 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 2));
+    mock.set(hal::percent::from_ratio(1, 2));
     expect(that % -150 == test.read().value());
-    mock.set(embed::percent::from_ratio(3, 4));
+    mock.set(hal::percent::from_ratio(3, 4));
     expect(that % -125 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 1));
+    mock.set(hal::percent::from_ratio(1, 1));
     expect(that % -100 == test.read().value());
-    mock.set(embed::percent::from_ratio(-1, 2));
+    mock.set(hal::percent::from_ratio(-1, 2));
     expect(that % -200 == test.read().value());
-    mock.set(embed::percent::from_ratio(2, 1));
+    mock.set(hal::percent::from_ratio(2, 1));
     expect(that % -100 == test.read().value());
   };
 
-  "embed::linear_potentiometer::read() large positive range"_test = []() {
+  "hal::linear_potentiometer::read() large positive range"_test = []() {
     // Setup
-    embed::mock::adc mock(embed::percent::from_ratio(0, 1));
-    embed::linear_potentiometer::settings settings;
+    hal::mock::adc mock(hal::percent::from_ratio(0, 1));
+    hal::linear_potentiometer::settings settings;
     settings.p_min_distance = 0;
     settings.p_max_distance = 400000000;
-    settings.p_min_adc_output = embed::percent::from_ratio(0, 1);
-    settings.p_max_adc_output = embed::percent::from_ratio(1, 1);
-    embed::linear_potentiometer test(mock, settings);
+    settings.p_min_adc_output = hal::percent::from_ratio(0, 1);
+    settings.p_max_adc_output = hal::percent::from_ratio(1, 1);
+    hal::linear_potentiometer test(mock, settings);
 
     // Exercise + Verify
     expect(that % 0 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 4));
+    mock.set(hal::percent::from_ratio(1, 4));
     // division arithmetic
     expect(that % 100000000 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 2));
+    mock.set(hal::percent::from_ratio(1, 2));
     expect(that % 200000000 == test.read().value());
-    mock.set(embed::percent::from_ratio(3, 4));
+    mock.set(hal::percent::from_ratio(3, 4));
     expect(that % 300000000 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 1));
+    mock.set(hal::percent::from_ratio(1, 1));
     expect(that % 400000000 == test.read().value());
-    mock.set(embed::percent::from_ratio(2, 1));
+    mock.set(hal::percent::from_ratio(2, 1));
     expect(that % 400000000 == test.read().value());
-    mock.set(embed::percent::from_ratio(-1, 2));
+    mock.set(hal::percent::from_ratio(-1, 2));
     expect(that % 0 == test.read().value());
   };
 
-  "embed::linear_potentiometer::read() large negative range"_test = []() {
+  "hal::linear_potentiometer::read() large negative range"_test = []() {
     // Setup
-    embed::mock::adc mock(embed::percent::from_ratio(0, 1));
-    embed::linear_potentiometer::settings settings;
+    hal::mock::adc mock(hal::percent::from_ratio(0, 1));
+    hal::linear_potentiometer::settings settings;
     settings.p_min_distance = -400000000;
     settings.p_max_distance = 0;
-    settings.p_min_adc_output = embed::percent::from_ratio(0, 1);
-    settings.p_max_adc_output = embed::percent::from_ratio(1, 1);
-    embed::linear_potentiometer test(mock, settings);
+    settings.p_min_adc_output = hal::percent::from_ratio(0, 1);
+    settings.p_max_adc_output = hal::percent::from_ratio(1, 1);
+    hal::linear_potentiometer test(mock, settings);
 
     // Exercise + Verify
     expect(that % -400000000 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 4));
+    mock.set(hal::percent::from_ratio(1, 4));
     // TODO: Fix with issue #273, expected value adjusted to work with current
     // division arithmetic
     expect(that % -300000000 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 2));
+    mock.set(hal::percent::from_ratio(1, 2));
     expect(that % -200000000 == test.read().value());
-    mock.set(embed::percent::from_ratio(3, 4));
+    mock.set(hal::percent::from_ratio(3, 4));
     expect(that % -100000000 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 1));
+    mock.set(hal::percent::from_ratio(1, 1));
     expect(that % 0 == test.read().value());
-    mock.set(embed::percent::from_ratio(2, 1));
+    mock.set(hal::percent::from_ratio(2, 1));
     expect(that % 0 == test.read().value());
-    mock.set(embed::percent::from_ratio(-1, 2));
+    mock.set(hal::percent::from_ratio(-1, 2));
     expect(that % -400000000 == test.read().value());
   };
 
-  "embed::linear_potentiometer::read() range exceeds max integer value"_test =
+  "hal::linear_potentiometer::read() range exceeds max integer value"_test =
     []() {
       // Setup
-      embed::mock::adc mock(embed::percent::from_ratio(0, 1));
-      embed::linear_potentiometer::settings settings;
+      hal::mock::adc mock(hal::percent::from_ratio(0, 1));
+      hal::linear_potentiometer::settings settings;
       settings.p_min_distance = -400000000;
       settings.p_max_distance = 400000000;
-      settings.p_min_adc_output = embed::percent::from_ratio(0, 1);
-      settings.p_max_adc_output = embed::percent::from_ratio(1, 1);
-      embed::linear_potentiometer test(mock, settings);
+      settings.p_min_adc_output = hal::percent::from_ratio(0, 1);
+      settings.p_max_adc_output = hal::percent::from_ratio(1, 1);
+      hal::linear_potentiometer test(mock, settings);
 
       // Exercise + Verify
       expect(that % -400000000 == test.read().value());
-      mock.set(embed::percent::from_ratio(1, 4));
+      mock.set(hal::percent::from_ratio(1, 4));
       expect(that % -200000000 == test.read().value());
-      mock.set(embed::percent::from_ratio(3, 4));
+      mock.set(hal::percent::from_ratio(3, 4));
       expect(that % 200000000 == test.read().value());
-      mock.set(embed::percent::from_ratio(1, 1));
+      mock.set(hal::percent::from_ratio(1, 1));
       expect(that % 400000000 == test.read().value());
-      mock.set(embed::percent::from_ratio(2, 1));
+      mock.set(hal::percent::from_ratio(2, 1));
       expect(that % 400000000 == test.read().value());
-      mock.set(embed::percent::from_ratio(-1, 2));
+      mock.set(hal::percent::from_ratio(-1, 2));
       expect(that % -400000000 == test.read().value());
     };
 
-  "embed::linear_potentiometer::read() range in meters"_test = []() {
+  "hal::linear_potentiometer::read() range in meters"_test = []() {
     // Setup
-    embed::mock::adc mock(embed::percent::from_ratio(0, 1));
-    embed::linear_potentiometer::settings settings;
+    hal::mock::adc mock(hal::percent::from_ratio(0, 1));
+    hal::linear_potentiometer::settings settings;
     settings.p_min_distance = 100'000'000;
     settings.p_max_distance = 200'000'000;
-    settings.p_min_adc_output = embed::percent::from_ratio(0, 1);
-    settings.p_max_adc_output = embed::percent::from_ratio(1, 1);
-    embed::linear_potentiometer test(mock, settings);
+    settings.p_min_adc_output = hal::percent::from_ratio(0, 1);
+    settings.p_max_adc_output = hal::percent::from_ratio(1, 1);
+    hal::linear_potentiometer test(mock, settings);
 
     // Exercise + Verify
     expect(that % 100'000'000 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 4));
+    mock.set(hal::percent::from_ratio(1, 4));
     expect(that % 125'000'000 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 2));
+    mock.set(hal::percent::from_ratio(1, 2));
     expect(that % 150'000'000 == test.read().value());
-    mock.set(embed::percent::from_ratio(3, 4));
+    mock.set(hal::percent::from_ratio(3, 4));
     expect(that % 175'000'000 == test.read().value());
-    mock.set(embed::percent::from_ratio(1, 1));
+    mock.set(hal::percent::from_ratio(1, 1));
     expect(that % 200'000'000 == test.read().value());
-    mock.set(embed::percent::from_ratio(2, 1));
+    mock.set(hal::percent::from_ratio(2, 1));
     expect(that % 200'000'000 == test.read().value());
-    mock.set(embed::percent::from_ratio(-1, 2));
+    mock.set(hal::percent::from_ratio(-1, 2));
     expect(that % 100'000'000 == test.read().value());
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/experimental/rotary_encoder/interface.test.cpp
+++ b/tests/experimental/rotary_encoder/interface.test.cpp
@@ -1,10 +1,10 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/rotary_encoder/interface.hpp>
 
-namespace embed {
+namespace hal {
 namespace {
 constexpr auto expected_rotations = 1'000'000'000;
-class test_rotary_encoder : public embed::rotary_encoder
+class test_rotary_encoder : public hal::rotary_encoder
 {
 private:
   boost::leaf::result<microrotation> driver_read() noexcept override
@@ -25,4 +25,4 @@ boost::ut::suite rotary_encoder_test = []() {
   // Verify
   expect(expected_rotations == sample);
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/experimental/temperature/interface.test.cpp
+++ b/tests/experimental/temperature/interface.test.cpp
@@ -1,10 +1,10 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/temperature/interface.hpp>
 
-namespace embed {
+namespace hal {
 namespace {
 constexpr auto expected_temperature = 1'000'000'000;
-class test_temperature_sensor : public embed::temperature_sensor
+class test_temperature_sensor : public hal::temperature_sensor
 {
 private:
   boost::leaf::result<microkelvin> driver_read() noexcept override
@@ -25,4 +25,4 @@ boost::ut::suite temperature_test = []() {
   // Verify
   expect(expected_temperature == sample);
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/experimental/temperature/mock.test.cpp
+++ b/tests/experimental/temperature/mock.test.cpp
@@ -3,13 +3,13 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/temperature/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite temperature_mock_test = []() {
   using namespace boost::ut;
 
-  "embed::mock::temperature::read()"_test = []() {
+  "hal::mock::temperature::read()"_test = []() {
     // Setup
-    embed::mock::temperature_sensor mock;
+    hal::mock::temperature_sensor mock;
     auto expected1 = 0;
     auto expected2 = 1000;
     auto expected3 = 2000;
@@ -26,4 +26,4 @@ boost::ut::suite temperature_mock_test = []() {
     expect(throws([&mock] { mock.read().value(); }));
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/frequency.test.cpp
+++ b/tests/frequency.test.cpp
@@ -4,11 +4,11 @@
 
 #include "ostreams.hpp"
 
-namespace embed {
+namespace hal {
 boost::ut::suite frequency_user_defined_literals_test = []() {
   using namespace boost::ut;
   using namespace std::literals;
-  using namespace embed::literals;
+  using namespace hal::literals;
 
   "frequency::user defined literals"_test = []() {
     expect(that % 1'000'000 == (1_MHz).value_hz);
@@ -357,4 +357,4 @@ boost::ut::suite frequency_user_defined_literals_test = []() {
               2));
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/i2c/util.test.cpp
+++ b/tests/i2c/util.test.cpp
@@ -2,7 +2,7 @@
 #include <libembeddedhal/i2c/util.hpp>
 #include <span>
 
-namespace embed {
+namespace hal {
 boost::ut::suite i2c_util_test = []() {
   using namespace boost::ut;
 
@@ -20,7 +20,7 @@ boost::ut::suite i2c_util_test = []() {
     bool was_called = false;
   };
 
-  class test_i2c : public embed::i2c
+  class test_i2c : public hal::i2c
   {
   public:
     [[nodiscard]] boost::leaf::result<void> driver_configure(
@@ -32,7 +32,7 @@ boost::ut::suite i2c_util_test = []() {
       std::byte p_address,
       std::span<const std::byte> p_out,
       std::span<std::byte> p_in,
-      std::function<embed::timeout> p_timeout) noexcept override
+      std::function<hal::timeout> p_timeout) noexcept override
     {
       m_address = p_address;
       m_out = p_out;
@@ -275,4 +275,4 @@ boost::ut::suite i2c_util_test = []() {
     expect(that % false == test_timeout.was_called);
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/input_pin/mock.test.cpp
+++ b/tests/input_pin/mock.test.cpp
@@ -3,17 +3,17 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/input_pin/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite input_pin_mock_test = []() {
   using namespace boost::ut;
 
-  "embed::mock::inputput_pin::configure()"_test = []() {
+  "hal::mock::inputput_pin::configure()"_test = []() {
     // Setup
-    constexpr embed::input_pin::settings mock_settings_default{};
-    constexpr embed::input_pin::settings mock_settings_custom{
+    constexpr hal::input_pin::settings mock_settings_default{};
+    constexpr hal::input_pin::settings mock_settings_custom{
       .resistor = pin_resistor::pull_down,
     };
-    embed::mock::input_pin mock;
+    hal::mock::input_pin mock;
 
     // Exercise
     auto result1 = mock.configure(mock_settings_default);
@@ -27,9 +27,9 @@ boost::ut::suite input_pin_mock_test = []() {
     expect(mock_settings_custom ==
            std::get<0>(mock.spy_configure.call_history().at(1)));
   };
-  "embed::mock::input_pin::set() + level()"_test = []() {
+  "hal::mock::input_pin::set() + level()"_test = []() {
     // Setup
-    embed::mock::input_pin mock;
+    hal::mock::input_pin mock;
     std::deque inputs{ true, false, true };
     std::queue queue(inputs);
 
@@ -42,10 +42,10 @@ boost::ut::suite input_pin_mock_test = []() {
     expect(that % true == mock.level().value());
     expect(throws([&mock] { mock.level().value(); }));
   };
-  "embed::mock::input_pin::reset()"_test = []() {
+  "hal::mock::input_pin::reset()"_test = []() {
     // Setup
-    constexpr embed::input_pin::settings mock_settings_default{};
-    embed::mock::input_pin mock;
+    constexpr hal::input_pin::settings mock_settings_default{};
+    hal::mock::input_pin mock;
     (void)mock.configure(mock_settings_default);
     expect(that % 1 == mock.spy_configure.call_history().size());
 
@@ -56,4 +56,4 @@ boost::ut::suite input_pin_mock_test = []() {
     expect(that % 0 == mock.spy_configure.call_history().size());
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/interrupt_pin/mock.test.cpp
+++ b/tests/interrupt_pin/mock.test.cpp
@@ -3,17 +3,17 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/interrupt_pin/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite interrupt_pin_mock_test = []() {
   using namespace boost::ut;
 
-  "embed::mock::interrupt_pin::configure()"_test = []() {
+  "hal::mock::interrupt_pin::configure()"_test = []() {
     // Setup
-    constexpr embed::interrupt_pin::settings mock_settings_default{};
-    constexpr embed::interrupt_pin::settings mock_settings_custom{
+    constexpr hal::interrupt_pin::settings mock_settings_default{};
+    constexpr hal::interrupt_pin::settings mock_settings_custom{
       .resistor = pin_resistor::pull_down,
     };
-    embed::mock::interrupt_pin mock;
+    hal::mock::interrupt_pin mock;
 
     // Exercise
     auto result1 = mock.configure(mock_settings_default);
@@ -27,9 +27,9 @@ boost::ut::suite interrupt_pin_mock_test = []() {
     expect(mock_settings_custom.resistor ==
            std::get<0>(mock.spy_configure.call_history().at(1)).resistor);
   };
-  "embed::mock::interrupt_pin::set() + level()"_test = []() {
+  "hal::mock::interrupt_pin::set() + level()"_test = []() {
     // Setup
-    embed::mock::interrupt_pin mock;
+    hal::mock::interrupt_pin mock;
     std::deque inputs{ true, false, true };
     std::queue queue(inputs);
 
@@ -42,9 +42,9 @@ boost::ut::suite interrupt_pin_mock_test = []() {
     expect(that % true == mock.level().value());
     expect(throws([&mock] { mock.level().value(); }));
   };
-  "embed::mock::interrupt_pin::detach_interrupt()"_test = []() {
+  "hal::mock::interrupt_pin::detach_interrupt()"_test = []() {
     // Setup
-    embed::mock::interrupt_pin mock;
+    hal::mock::interrupt_pin mock;
 
     // Exercise
     (void)mock.detach_interrupt();
@@ -53,16 +53,16 @@ boost::ut::suite interrupt_pin_mock_test = []() {
     expect(that % true ==
            std::get<0>(mock.spy_detach_interrupt.call_history().at(0)));
   };
-  "embed::mock::interrupt_pin::attach_interrupt()"_test = []() {
+  "hal::mock::interrupt_pin::attach_interrupt()"_test = []() {
     // Setup
     const std::function<void(void)> expected_callback = []() {};
-    const embed::interrupt_pin::trigger_edge expected_falling =
-      embed::interrupt_pin::trigger_edge::falling;
-    const embed::interrupt_pin::trigger_edge expected_rising =
-      embed::interrupt_pin::trigger_edge::rising;
-    const embed::interrupt_pin::trigger_edge expected_both =
-      embed::interrupt_pin::trigger_edge::both;
-    embed::mock::interrupt_pin mock;
+    const hal::interrupt_pin::trigger_edge expected_falling =
+      hal::interrupt_pin::trigger_edge::falling;
+    const hal::interrupt_pin::trigger_edge expected_rising =
+      hal::interrupt_pin::trigger_edge::rising;
+    const hal::interrupt_pin::trigger_edge expected_both =
+      hal::interrupt_pin::trigger_edge::both;
+    hal::mock::interrupt_pin mock;
 
     // Exercise
     auto result1 = mock.attach_interrupt(expected_callback, expected_falling);
@@ -80,13 +80,13 @@ boost::ut::suite interrupt_pin_mock_test = []() {
     expect(expected_both ==
            std::get<1>(mock.spy_attach_interrupt.call_history().at(2)));
   };
-  "embed::mock::interrupt_pin::reset()"_test = []() {
+  "hal::mock::interrupt_pin::reset()"_test = []() {
     // Setup
-    constexpr embed::interrupt_pin::settings mock_settings_default{};
+    constexpr hal::interrupt_pin::settings mock_settings_default{};
     const std::function<void(void)> expected_callback = []() {};
-    const embed::interrupt_pin::trigger_edge expected_trigger =
-      embed::interrupt_pin::trigger_edge::falling;
-    embed::mock::interrupt_pin mock;
+    const hal::interrupt_pin::trigger_edge expected_trigger =
+      hal::interrupt_pin::trigger_edge::falling;
+    hal::mock::interrupt_pin mock;
     (void)mock.configure(mock_settings_default);
     expect(that % 1 == mock.spy_configure.call_history().size());
     (void)mock.attach_interrupt(expected_callback, expected_trigger);
@@ -103,4 +103,4 @@ boost::ut::suite interrupt_pin_mock_test = []() {
     expect(that % 0 == mock.spy_detach_interrupt.call_history().size());
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/libembeddedhal.tweaks.hpp
+++ b/tests/libembeddedhal.tweaks.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-namespace embed::config {
+namespace hal::config {
 inline int callback_call_count = 0;
 constexpr bool on_error_callback_enabled = true;
 constexpr auto on_error_callback = []() { callback_call_count++; };
-}  // namespace embed::config
+}  // namespace hal::config

--- a/tests/map.test.cpp
+++ b/tests/map.test.cpp
@@ -1,11 +1,11 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/map.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite map_test = []() {
   using namespace boost::ut;
 
-  "embed::map()"_test = []() {
+  "hal::map()"_test = []() {
     "Zero"_test = []() {
       expect(that % 0 ==
              map(0, { .x = 0, .y = 10 }, { .x = 0, .y = 100 }).value());

--- a/tests/math.test.cpp
+++ b/tests/math.test.cpp
@@ -1,11 +1,11 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/math.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite math_test = []() {
   using namespace boost::ut;
 
-  "embed::multiply()"_test = []() {
+  "hal::multiply()"_test = []() {
     "Zero"_test = []() { expect(that % 0 == multiply(0, 0).value()); };
     "One"_test = []() { expect(that % 1 == multiply(1, 1).value()); };
     "Boundaries"_test = []() {
@@ -31,7 +31,7 @@ boost::ut::suite math_test = []() {
     };
   };
 
-  "embed::distance()"_test = []() {
+  "hal::distance()"_test = []() {
     "Zero"_test = []() { expect(that % 0 == distance(0, 0)); };
     "One"_test = []() { expect(that % 1 == distance(0, 1)); };
     "Boundaries"_test = []() {

--- a/tests/motor/mock.test.cpp
+++ b/tests/motor/mock.test.cpp
@@ -1,12 +1,12 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/motor/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite motor_mock_test = []() {
   using namespace boost::ut;
 
   // Setup
-  embed::mock::motor mock;
+  hal::mock::motor mock;
   constexpr auto expected1 = percent::from_ratio(1, 2);
   constexpr auto expected2 = percent::from_ratio(1, 4);
   mock.spy_power.trigger_error_on_call(3);
@@ -21,4 +21,4 @@ boost::ut::suite motor_mock_test = []() {
   expect(!mock.power(expected2));
   expect(expected2 == std::get<0>(mock.spy_power.call_history().at(2)));
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/motor/motor_mock.test.cpp
+++ b/tests/motor/motor_mock.test.cpp
@@ -1,12 +1,12 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/motor/motor_mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite motor_mock_test = []() {
   using namespace boost::ut;
 
   // Setup
-  embed::mock::motor mock;
+  hal::mock::motor mock;
   constexpr auto expected1 = percent::from_ratio(1, 2);
   constexpr auto expected2 = percent::from_ratio(1, 4);
   mock.spy_power.trigger_error_on_call(3);
@@ -21,4 +21,4 @@ boost::ut::suite motor_mock_test = []() {
   expect(!mock.power(expected2));
   expect(expected2 == std::get<0>(mock.spy_power.call_history().at(2)));
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/ostreams.hpp
+++ b/tests/ostreams.hpp
@@ -19,7 +19,7 @@ inline std::ostream& operator<<(
 }
 }  // namespace
 
-namespace embed {
+namespace hal {
 inline std::ostream& operator<<(std::ostream& os, const frequency& p_frequency)
 {
   return (os << p_frequency.value_hz << "_Hz");
@@ -47,4 +47,4 @@ inline std::ostream& operator<<(std::ostream& os,
              << std::setfill(' ') << std::setw(10) << p_percent.value()
              << " }");
 }
-}  // namespace embed
+}  // namespace hal

--- a/tests/output_pin/mock.test.cpp
+++ b/tests/output_pin/mock.test.cpp
@@ -1,19 +1,19 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/output_pin/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite output_pin_mock_test = []() {
   using namespace boost::ut;
 
-  "embed::mock::output_pin::configure()"_test = []() {
+  "hal::mock::output_pin::configure()"_test = []() {
     // Setup
-    constexpr embed::output_pin::settings mock_settings_default{};
-    constexpr embed::output_pin::settings mock_settings_custom{
+    constexpr hal::output_pin::settings mock_settings_default{};
+    constexpr hal::output_pin::settings mock_settings_custom{
       .resistor = pin_resistor::pull_down,
       .open_drain = true,
       .starting_level = false,
     };
-    embed::mock::output_pin mock;
+    hal::mock::output_pin mock;
 
     // Exercise
     auto result1 = mock.configure(mock_settings_default);
@@ -28,9 +28,9 @@ boost::ut::suite output_pin_mock_test = []() {
     expect(bool{ result2 });
   };
 
-  "embed::mock::output_pin::driver_level(bool)"_test = []() {
+  "hal::mock::output_pin::driver_level(bool)"_test = []() {
     // Setup
-    embed::mock::output_pin mock;
+    hal::mock::output_pin mock;
 
     // Exercise
     auto result1 = mock.level(true);
@@ -43,9 +43,9 @@ boost::ut::suite output_pin_mock_test = []() {
     expect(that % false == std::get<0>(mock.spy_level.call_history().at(1)));
   };
 
-  "embed::mock::output_pin::driver_level()"_test = []() {
+  "hal::mock::output_pin::driver_level()"_test = []() {
     // Setup
-    embed::mock::output_pin mock;
+    hal::mock::output_pin mock;
 
     // Exercise
     (void)mock.level(true);
@@ -60,10 +60,10 @@ boost::ut::suite output_pin_mock_test = []() {
     expect(that % false == result2.value());
   };
 
-  "embed::mock::output_pin::reset()"_test = []() {
+  "hal::mock::output_pin::reset()"_test = []() {
     // Setup
-    constexpr embed::output_pin::settings mock_settings_default{};
-    embed::mock::output_pin mock;
+    constexpr hal::output_pin::settings mock_settings_default{};
+    hal::mock::output_pin mock;
     (void)mock.configure(mock_settings_default);
     (void)mock.level(false);
 
@@ -75,4 +75,4 @@ boost::ut::suite output_pin_mock_test = []() {
     expect(that % 0 == mock.spy_level.call_history().size());
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/overflow_counter.test.cpp
+++ b/tests/overflow_counter.test.cpp
@@ -1,7 +1,7 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/overflow_counter.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite overflow_counter_test = []() {
   using namespace boost::ut;
 
@@ -106,4 +106,4 @@ boost::ut::suite overflow_counter_test = []() {
     expect(that % 0x00A == counter.update(0xA));
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/percent.test.cpp
+++ b/tests/percent.test.cpp
@@ -2,95 +2,95 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/percent.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite percent_ratio_and_cast_test = []() {
   using namespace boost::ut;
 
   // Float Testing
-  expect(0.50_d == embed::percent::from_ratio(1, 2).to<float>());
-  expect(0.50_d == embed::percent::from_ratio(2, 4).to<float>());
-  expect(0.20_d == embed::percent::from_ratio(1, 5).to<float>());
+  expect(0.50_d == hal::percent::from_ratio(1, 2).to<float>());
+  expect(0.50_d == hal::percent::from_ratio(2, 4).to<float>());
+  expect(0.20_d == hal::percent::from_ratio(1, 5).to<float>());
 
-  expect(0.010_d == embed::percent::from_ratio(1, 100).to<float>());
-  expect(0.020_d == embed::percent::from_ratio(2, 100).to<float>());
-  expect(0.070_d == embed::percent::from_ratio(7, 100).to<float>());
-  expect(0.080_d == embed::percent::from_ratio(8, 100).to<float>());
-  expect(0.100_d == embed::percent::from_ratio(10, 100).to<float>());
-  expect(0.120_d == embed::percent::from_ratio(12, 100).to<float>());
-  expect(0.250_d == embed::percent::from_ratio(25, 100).to<float>());
-  expect(0.330_d == embed::percent::from_ratio(33, 100).to<float>());
-  expect(0.460_d == embed::percent::from_ratio(46, 100).to<float>());
-  expect(0.520_d == embed::percent::from_ratio(52, 100).to<float>());
-  expect(0.550_d == embed::percent::from_ratio(55, 100).to<float>());
-  expect(0.670_d == embed::percent::from_ratio(67, 100).to<float>());
-  expect(0.750_d == embed::percent::from_ratio(75, 100).to<float>());
-  expect(0.810_d == embed::percent::from_ratio(81, 100).to<float>());
-  expect(0.900_d == embed::percent::from_ratio(90, 100).to<float>());
-  expect(0.940_d == embed::percent::from_ratio(94, 100).to<float>());
-  expect(1.000_d == embed::percent::from_ratio(100, 100).to<float>());
+  expect(0.010_d == hal::percent::from_ratio(1, 100).to<float>());
+  expect(0.020_d == hal::percent::from_ratio(2, 100).to<float>());
+  expect(0.070_d == hal::percent::from_ratio(7, 100).to<float>());
+  expect(0.080_d == hal::percent::from_ratio(8, 100).to<float>());
+  expect(0.100_d == hal::percent::from_ratio(10, 100).to<float>());
+  expect(0.120_d == hal::percent::from_ratio(12, 100).to<float>());
+  expect(0.250_d == hal::percent::from_ratio(25, 100).to<float>());
+  expect(0.330_d == hal::percent::from_ratio(33, 100).to<float>());
+  expect(0.460_d == hal::percent::from_ratio(46, 100).to<float>());
+  expect(0.520_d == hal::percent::from_ratio(52, 100).to<float>());
+  expect(0.550_d == hal::percent::from_ratio(55, 100).to<float>());
+  expect(0.670_d == hal::percent::from_ratio(67, 100).to<float>());
+  expect(0.750_d == hal::percent::from_ratio(75, 100).to<float>());
+  expect(0.810_d == hal::percent::from_ratio(81, 100).to<float>());
+  expect(0.900_d == hal::percent::from_ratio(90, 100).to<float>());
+  expect(0.940_d == hal::percent::from_ratio(94, 100).to<float>());
+  expect(1.000_d == hal::percent::from_ratio(100, 100).to<float>());
 
-  expect(0.0020_d == embed::percent::from_ratio(1, 500).to<float>());
-  expect(0.0040_d == embed::percent::from_ratio(2, 500).to<float>());
-  expect(0.0140_d == embed::percent::from_ratio(7, 500).to<float>());
-  expect(0.0160_d == embed::percent::from_ratio(8, 500).to<float>());
-  expect(0.0200_d == embed::percent::from_ratio(10, 500).to<float>());
-  expect(0.0240_d == embed::percent::from_ratio(12, 500).to<float>());
-  expect(0.0500_d == embed::percent::from_ratio(25, 500).to<float>());
-  expect(0.0660_d == embed::percent::from_ratio(33, 500).to<float>());
-  expect(0.0920_d == embed::percent::from_ratio(46, 500).to<float>());
-  expect(0.1040_d == embed::percent::from_ratio(52, 500).to<float>());
-  expect(0.1100_d == embed::percent::from_ratio(55, 500).to<float>());
-  expect(0.1340_d == embed::percent::from_ratio(67, 500).to<float>());
-  expect(0.1500_d == embed::percent::from_ratio(75, 500).to<float>());
-  expect(0.1620_d == embed::percent::from_ratio(81, 500).to<float>());
-  expect(0.1800_d == embed::percent::from_ratio(90, 500).to<float>());
-  expect(0.1880_d == embed::percent::from_ratio(94, 500).to<float>());
-  expect(0.2000_d == embed::percent::from_ratio(100, 500).to<float>());
-  expect(0.4000_d == embed::percent::from_ratio(200, 500).to<float>());
-  expect(0.6000_d == embed::percent::from_ratio(300, 500).to<float>());
-  expect(0.8000_d == embed::percent::from_ratio(400, 500).to<float>());
-  expect(1.0000_d == embed::percent::from_ratio(500, 500).to<float>());
+  expect(0.0020_d == hal::percent::from_ratio(1, 500).to<float>());
+  expect(0.0040_d == hal::percent::from_ratio(2, 500).to<float>());
+  expect(0.0140_d == hal::percent::from_ratio(7, 500).to<float>());
+  expect(0.0160_d == hal::percent::from_ratio(8, 500).to<float>());
+  expect(0.0200_d == hal::percent::from_ratio(10, 500).to<float>());
+  expect(0.0240_d == hal::percent::from_ratio(12, 500).to<float>());
+  expect(0.0500_d == hal::percent::from_ratio(25, 500).to<float>());
+  expect(0.0660_d == hal::percent::from_ratio(33, 500).to<float>());
+  expect(0.0920_d == hal::percent::from_ratio(46, 500).to<float>());
+  expect(0.1040_d == hal::percent::from_ratio(52, 500).to<float>());
+  expect(0.1100_d == hal::percent::from_ratio(55, 500).to<float>());
+  expect(0.1340_d == hal::percent::from_ratio(67, 500).to<float>());
+  expect(0.1500_d == hal::percent::from_ratio(75, 500).to<float>());
+  expect(0.1620_d == hal::percent::from_ratio(81, 500).to<float>());
+  expect(0.1800_d == hal::percent::from_ratio(90, 500).to<float>());
+  expect(0.1880_d == hal::percent::from_ratio(94, 500).to<float>());
+  expect(0.2000_d == hal::percent::from_ratio(100, 500).to<float>());
+  expect(0.4000_d == hal::percent::from_ratio(200, 500).to<float>());
+  expect(0.6000_d == hal::percent::from_ratio(300, 500).to<float>());
+  expect(0.8000_d == hal::percent::from_ratio(400, 500).to<float>());
+  expect(1.0000_d == hal::percent::from_ratio(500, 500).to<float>());
 
   // Double Testing
-  expect(0.010_d == embed::percent::from_ratio(1, 100).to<double>());
-  expect(0.020_d == embed::percent::from_ratio(2, 100).to<double>());
-  expect(0.070_d == embed::percent::from_ratio(7, 100).to<double>());
-  expect(0.080_d == embed::percent::from_ratio(8, 100).to<double>());
-  expect(0.100_d == embed::percent::from_ratio(10, 100).to<double>());
-  expect(0.120_d == embed::percent::from_ratio(12, 100).to<double>());
-  expect(0.250_d == embed::percent::from_ratio(25, 100).to<double>());
-  expect(0.330_d == embed::percent::from_ratio(33, 100).to<double>());
-  expect(0.460_d == embed::percent::from_ratio(46, 100).to<double>());
-  expect(0.520_d == embed::percent::from_ratio(52, 100).to<double>());
-  expect(0.550_d == embed::percent::from_ratio(55, 100).to<double>());
-  expect(0.670_d == embed::percent::from_ratio(67, 100).to<double>());
-  expect(0.750_d == embed::percent::from_ratio(75, 100).to<double>());
-  expect(0.810_d == embed::percent::from_ratio(81, 100).to<double>());
-  expect(0.900_d == embed::percent::from_ratio(90, 100).to<double>());
-  expect(0.940_d == embed::percent::from_ratio(94, 100).to<double>());
-  expect(1.000_d == embed::percent::from_ratio(100, 100).to<double>());
+  expect(0.010_d == hal::percent::from_ratio(1, 100).to<double>());
+  expect(0.020_d == hal::percent::from_ratio(2, 100).to<double>());
+  expect(0.070_d == hal::percent::from_ratio(7, 100).to<double>());
+  expect(0.080_d == hal::percent::from_ratio(8, 100).to<double>());
+  expect(0.100_d == hal::percent::from_ratio(10, 100).to<double>());
+  expect(0.120_d == hal::percent::from_ratio(12, 100).to<double>());
+  expect(0.250_d == hal::percent::from_ratio(25, 100).to<double>());
+  expect(0.330_d == hal::percent::from_ratio(33, 100).to<double>());
+  expect(0.460_d == hal::percent::from_ratio(46, 100).to<double>());
+  expect(0.520_d == hal::percent::from_ratio(52, 100).to<double>());
+  expect(0.550_d == hal::percent::from_ratio(55, 100).to<double>());
+  expect(0.670_d == hal::percent::from_ratio(67, 100).to<double>());
+  expect(0.750_d == hal::percent::from_ratio(75, 100).to<double>());
+  expect(0.810_d == hal::percent::from_ratio(81, 100).to<double>());
+  expect(0.900_d == hal::percent::from_ratio(90, 100).to<double>());
+  expect(0.940_d == hal::percent::from_ratio(94, 100).to<double>());
+  expect(1.000_d == hal::percent::from_ratio(100, 100).to<double>());
 
-  expect(0.0020_d == embed::percent::from_ratio(1, 500).to<double>());
-  expect(0.0040_d == embed::percent::from_ratio(2, 500).to<double>());
-  expect(0.0140_d == embed::percent::from_ratio(7, 500).to<double>());
-  expect(0.0160_d == embed::percent::from_ratio(8, 500).to<double>());
-  expect(0.0200_d == embed::percent::from_ratio(10, 500).to<double>());
-  expect(0.0240_d == embed::percent::from_ratio(12, 500).to<double>());
-  expect(0.0500_d == embed::percent::from_ratio(25, 500).to<double>());
-  expect(0.0660_d == embed::percent::from_ratio(33, 500).to<double>());
-  expect(0.0920_d == embed::percent::from_ratio(46, 500).to<double>());
-  expect(0.1040_d == embed::percent::from_ratio(52, 500).to<double>());
-  expect(0.1100_d == embed::percent::from_ratio(55, 500).to<double>());
-  expect(0.1340_d == embed::percent::from_ratio(67, 500).to<double>());
-  expect(0.1500_d == embed::percent::from_ratio(75, 500).to<double>());
-  expect(0.1620_d == embed::percent::from_ratio(81, 500).to<double>());
-  expect(0.1800_d == embed::percent::from_ratio(90, 500).to<double>());
-  expect(0.1880_d == embed::percent::from_ratio(94, 500).to<double>());
-  expect(0.2000_d == embed::percent::from_ratio(100, 500).to<double>());
-  expect(0.4000_d == embed::percent::from_ratio(200, 500).to<double>());
-  expect(0.6000_d == embed::percent::from_ratio(300, 500).to<double>());
-  expect(0.8000_d == embed::percent::from_ratio(400, 500).to<double>());
-  expect(1.0000_d == embed::percent::from_ratio(500, 500).to<double>());
+  expect(0.0020_d == hal::percent::from_ratio(1, 500).to<double>());
+  expect(0.0040_d == hal::percent::from_ratio(2, 500).to<double>());
+  expect(0.0140_d == hal::percent::from_ratio(7, 500).to<double>());
+  expect(0.0160_d == hal::percent::from_ratio(8, 500).to<double>());
+  expect(0.0200_d == hal::percent::from_ratio(10, 500).to<double>());
+  expect(0.0240_d == hal::percent::from_ratio(12, 500).to<double>());
+  expect(0.0500_d == hal::percent::from_ratio(25, 500).to<double>());
+  expect(0.0660_d == hal::percent::from_ratio(33, 500).to<double>());
+  expect(0.0920_d == hal::percent::from_ratio(46, 500).to<double>());
+  expect(0.1040_d == hal::percent::from_ratio(52, 500).to<double>());
+  expect(0.1100_d == hal::percent::from_ratio(55, 500).to<double>());
+  expect(0.1340_d == hal::percent::from_ratio(67, 500).to<double>());
+  expect(0.1500_d == hal::percent::from_ratio(75, 500).to<double>());
+  expect(0.1620_d == hal::percent::from_ratio(81, 500).to<double>());
+  expect(0.1800_d == hal::percent::from_ratio(90, 500).to<double>());
+  expect(0.1880_d == hal::percent::from_ratio(94, 500).to<double>());
+  expect(0.2000_d == hal::percent::from_ratio(100, 500).to<double>());
+  expect(0.4000_d == hal::percent::from_ratio(200, 500).to<double>());
+  expect(0.6000_d == hal::percent::from_ratio(300, 500).to<double>());
+  expect(0.8000_d == hal::percent::from_ratio(400, 500).to<double>());
+  expect(1.0000_d == hal::percent::from_ratio(500, 500).to<double>());
 };
 
 boost::ut::suite percent_signed_test = []() {
@@ -98,70 +98,70 @@ boost::ut::suite percent_signed_test = []() {
 
   "4-bit_scaling"_test = []() {
     // Setup
-    embed::percent value;
+    hal::percent value;
     int32_t expected = 0;
 
     // Exercise
-    value = embed::percent::convert<4>(7);
+    value = hal::percent::convert<4>(7);
     expect(that % 0b0111'1111'1111'1111'1111'1111'1111'1111 ==
            value.raw_value());
 
-    value = embed::percent::convert<4>(6);
+    value = hal::percent::convert<4>(6);
     expect(that % 0b0110'1101'1011'0110'1101'1011'0110'1101 ==
            value.raw_value());
 
-    value = embed::percent::convert<4>(5);
+    value = hal::percent::convert<4>(5);
     expect(that % 0b0101'1011'0110'1101'1011'0110'1101'1011 ==
            value.raw_value());
 
-    value = embed::percent::convert<4>(4);
+    value = hal::percent::convert<4>(4);
     expect(that % 0b0100'1001'0010'0100'1001'0010'0100'1001 ==
            value.raw_value());
 
-    value = embed::percent::convert<4>(3);
+    value = hal::percent::convert<4>(3);
     expect(that % 0b0011'0110'1101'1011'0110'1101'1011'0110 ==
            value.raw_value());
 
-    value = embed::percent::convert<4>(2);
+    value = hal::percent::convert<4>(2);
     expect(that % 0b0010'0100'1001'0010'0100'1001'0010'0100 ==
            value.raw_value());
 
-    value = embed::percent::convert<4>(1);
+    value = hal::percent::convert<4>(1);
     expect(that % 0b0001'0010'0100'1001'0010'0100'1001'0010 ==
            value.raw_value());
 
-    value = embed::percent::convert<4>(0);
+    value = hal::percent::convert<4>(0);
     expect(that % 0 == value.raw_value());
 
-    value = embed::percent::convert<4>(-1);
+    value = hal::percent::convert<4>(-1);
     expected = 0b1111 << 28;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<4>(-2);
+    value = hal::percent::convert<4>(-2);
     expected = 0b1110 << 28;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<4>(-3);
+    value = hal::percent::convert<4>(-3);
     expected = 0b1101 << 28;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<4>(-4);
+    value = hal::percent::convert<4>(-4);
     expected = 0b1100 << 28;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<4>(-5);
+    value = hal::percent::convert<4>(-5);
     expected = 0b1011 << 28;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<4>(-6);
+    value = hal::percent::convert<4>(-6);
     expected = 0b1010 << 28;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<4>(-7);
+    value = hal::percent::convert<4>(-7);
     expected = 0b1001 << 28;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<4>(-8);
+    value = hal::percent::convert<4>(-8);
     expected = 0b1000 << 28;
     expect(that % expected == value.raw_value());
   };
@@ -183,64 +183,64 @@ boost::ut::suite percent_signed_test = []() {
 
   "16-bit_scaling"_test = []() {
     // Setup
-    embed::percent value;
+    hal::percent value;
     int32_t expected = 0;
 
     // Exercise
-    value = embed::percent::convert<16>((1 << 15) - 1);
+    value = hal::percent::convert<16>((1 << 15) - 1);
     expect(that % 0b0111'1111'1111'1111'1111'1111'1111'1111 ==
            value.raw_value());
 
-    value = embed::percent::convert<16>(0x0ABC);
+    value = hal::percent::convert<16>(0x0ABC);
     expect(that % (0x0ABC'0000 | (0x0ABC << 1)) == value.raw_value());
 
-    // value = embed::percent::convert<16>(5);
+    // value = hal::percent::convert<16>(5);
     // expect(that % 0b0 == value.raw_value());
 
-    // value = embed::percent::convert<16>(4);
+    // value = hal::percent::convert<16>(4);
     // expect(that % 0b0 == value.raw_value());
 
-    // value = embed::percent::convert<16>(3);
+    // value = hal::percent::convert<16>(3);
     // expect(that % 0b0 == value.raw_value());
 
-    // value = embed::percent::convert<16>(2);
+    // value = hal::percent::convert<16>(2);
     // expect(that % 0b0 == value.raw_value());
 
-    value = embed::percent::convert<16>(1);
+    value = hal::percent::convert<16>(1);
     expect(that % (0x0001'0000 | (0x0001 << 1)) == value.raw_value());
 
-    value = embed::percent::convert<16>(0);
+    value = hal::percent::convert<16>(0);
     expect(that % 0 == value.raw_value());
 
-    value = embed::percent::convert<16>(-1);
+    value = hal::percent::convert<16>(-1);
     expected = 0b1111'1111'1111'1111 << 16;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<16>(-2);
+    value = hal::percent::convert<16>(-2);
     expected = 0b1111'1111'1111'1110 << 16;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<16>(-3);
+    value = hal::percent::convert<16>(-3);
     expected = 0b1111'1111'1111'1101 << 16;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<16>(-4);
+    value = hal::percent::convert<16>(-4);
     expected = 0b1111'1111'1111'1100 << 16;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<16>(-5);
+    value = hal::percent::convert<16>(-5);
     expected = 0b1111'1111'1111'1011 << 16;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<16>(-6);
+    value = hal::percent::convert<16>(-6);
     expected = 0b1111'1111'1111'1010 << 16;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<16>(-7);
+    value = hal::percent::convert<16>(-7);
     expected = 0b1111'1111'1111'1001 << 16;
     expect(that % expected == value.raw_value());
 
-    value = embed::percent::convert<16>(-8);
+    value = hal::percent::convert<16>(-8);
     expected = 0b1111'1111'1111'1000 << 16;
     expect(that % expected == value.raw_value());
   };
@@ -670,4 +670,4 @@ boost::ut::suite percent_scale_test = []() {
     expect(that % expected_0_percent == actual);
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/percentage.test.cpp
+++ b/tests/percentage.test.cpp
@@ -2,40 +2,40 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/percentage.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite percentage_test = []() {
   using namespace boost::ut;
 
   "ctor: zero"_test = []() {
-    expect(that % 0.0_d == embed::percentage(0.0).value());
-    expect(that % 0.0_f == embed::percentage(0.0f).value());
-    embed::percentage<double> assign_double = 0.0;
+    expect(that % 0.0_d == hal::percentage(0.0).value());
+    expect(that % 0.0_f == hal::percentage(0.0f).value());
+    hal::percentage<double> assign_double = 0.0;
     expect(that % 0.0_d == assign_double.value());
-    embed::percentage<float> assign_float = 0.0f;
+    hal::percentage<float> assign_float = 0.0f;
     expect(that % 0.0_f == assign_float.value());
   };
 
   "ctor: standard"_test = []() {
-    expect(that % 0.222_d == embed::percentage(0.222).value());
-    expect(that % 0.123_d == embed::percentage(0.123).value());
-    expect(that % 0.875_d == embed::percentage(0.875).value());
-    expect(that % 0.999_d == embed::percentage(0.999).value());
-    expect(that % 0.347_d == embed::percentage(0.347).value());
+    expect(that % 0.222_d == hal::percentage(0.222).value());
+    expect(that % 0.123_d == hal::percentage(0.123).value());
+    expect(that % 0.875_d == hal::percentage(0.875).value());
+    expect(that % 0.999_d == hal::percentage(0.999).value());
+    expect(that % 0.347_d == hal::percentage(0.347).value());
   };
 
   "ctor: out of bounds"_test = []() {
-    expect(that % 1.0_d == embed::percentage(1.5).value());
-    expect(that % -1.0_d == embed::percentage(-1.5).value());
-    expect(that % 1.0_f == embed::percentage(1.5f).value());
-    expect(that % -1.0_f == embed::percentage(-1.5f).value());
-    embed::percentage<double> assign_double = 1.5;
+    expect(that % 1.0_d == hal::percentage(1.5).value());
+    expect(that % -1.0_d == hal::percentage(-1.5).value());
+    expect(that % 1.0_f == hal::percentage(1.5f).value());
+    expect(that % -1.0_f == hal::percentage(-1.5f).value());
+    hal::percentage<double> assign_double = 1.5;
     expect(that % 1.0_d == assign_double.value());
-    embed::percentage<float> assign_float = 1.5f;
+    hal::percentage<float> assign_float = 1.5f;
     expect(that % 1.0_f == assign_float.value());
-    embed::percentage<double> assign_double_neg = -1.5;
+    hal::percentage<double> assign_double_neg = -1.5;
     expect(that % -1.0_d == assign_double_neg.value());
-    embed::percentage<float> assign_float_neg = -1.5f;
+    hal::percentage<float> assign_float_neg = -1.5f;
     expect(that % -1.0_f == assign_float_neg.value());
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/pwm/mock.test.cpp
+++ b/tests/pwm/mock.test.cpp
@@ -1,19 +1,19 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/pwm/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite pwm_mock_test = []() {
   using namespace boost::ut;
 
-  "embed::mock::pwm::configure()"_test = []() {
+  "hal::mock::pwm::configure()"_test = []() {
     // Setup
-    constexpr embed::pwm::settings expected1 = {
+    constexpr hal::pwm::settings expected1 = {
       .frequency = frequency(1'000),
     };
-    constexpr embed::pwm::settings expected2 = {
+    constexpr hal::pwm::settings expected2 = {
       .frequency = frequency(10'000),
     };
-    embed::mock::pwm mock;
+    hal::mock::pwm mock;
     mock.spy_configure.trigger_error_on_call(3);
 
     // Exercise + Verify
@@ -27,11 +27,11 @@ boost::ut::suite pwm_mock_test = []() {
     expect(expected2 == std::get<0>(mock.spy_configure.call_history().at(2)));
   };
 
-  "embed::mock::pwm::duty_cycle()"_test = []() {
+  "hal::mock::pwm::duty_cycle()"_test = []() {
     // Setup
     constexpr auto expected1 = percent::from_ratio(1, 2);
     constexpr auto expected2 = percent::from_ratio(1, 4);
-    embed::mock::pwm mock;
+    hal::mock::pwm mock;
     mock.spy_duty_cycle.trigger_error_on_call(3);
 
     // Exercise + Verify
@@ -45,4 +45,4 @@ boost::ut::suite pwm_mock_test = []() {
     expect(expected2 == std::get<0>(mock.spy_duty_cycle.call_history().at(2)));
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/serial/util.test.cpp
+++ b/tests/serial/util.test.cpp
@@ -2,7 +2,7 @@
 #include <libembeddedhal/serial/util.hpp>
 #include <span>
 
-namespace embed {
+namespace hal {
 boost::ut::suite serial_util_test = []() {
   using namespace boost::ut;
   using namespace std::chrono_literals;
@@ -11,7 +11,7 @@ boost::ut::suite serial_util_test = []() {
   static constexpr std::byte write_failure_byte{ 0x33 };
   static constexpr std::byte filler_byte{ 0xA5 };
 
-  class dummy : public embed::serial
+  class dummy : public hal::serial
   {
   public:
     [[nodiscard]] boost::leaf::result<void> driver_configure(
@@ -55,7 +55,9 @@ boost::ut::suite serial_util_test = []() {
       return {};
     }
 
-    virtual ~dummy() {}
+    virtual ~dummy()
+    {
+    }
 
     std::span<const std::byte> m_out{};
     std::span<std::byte> m_in{};
@@ -382,4 +384,4 @@ boost::ut::suite serial_util_test = []() {
     expect(that % 5 == serial.m_bytes_available);
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/servo/interface.test.cpp
+++ b/tests/servo/interface.test.cpp
@@ -3,11 +3,11 @@
 
 #include "../ostreams.hpp"
 
-namespace embed {
+namespace hal {
 namespace {
 constexpr percent expected_value = percent::from_ratio(1, 2);
 
-class test_servo : public embed::servo
+class test_servo : public hal::servo
 {
 public:
   percent m_passed_position;
@@ -34,4 +34,4 @@ boost::ut::suite servo_test = []() {
   expect(bool{ result });
   expect(that % expected_value == test.m_passed_position);
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/servo/mock.test.cpp
+++ b/tests/servo/mock.test.cpp
@@ -1,13 +1,13 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/servo/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite servo_mock_test = []() {
   using namespace boost::ut;
 
-  "embed::mock::servo::position()"_test = []() {
+  "hal::mock::servo::position()"_test = []() {
     // Setup
-    embed::mock::servo mock;
+    hal::mock::servo mock;
     percent expected1 = percent::from_ratio(1, 2);
     percent expected2 = percent::from_ratio(1, 4);
 
@@ -22,4 +22,4 @@ boost::ut::suite servo_mock_test = []() {
     expect(expected2 == std::get<0>(mock.spy_position.call_history().at(1)));
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/servo/rc.test.cpp
+++ b/tests/servo/rc.test.cpp
@@ -4,24 +4,24 @@
 
 #include "ostreams.hpp"
 
-namespace embed {
+namespace hal {
 boost::ut::suite rc_servo_test = []() {
   using namespace boost::ut;
 
-  "embed::servo::rc_servo::create"_test = []() {
+  "hal::servo::rc_servo::create"_test = []() {
     // Setup
-    embed::mock::pwm pwm0;
-    embed::mock::pwm pwm1;
-    embed::mock::pwm pwm2;
+    hal::mock::pwm pwm0;
+    hal::mock::pwm pwm1;
+    hal::mock::pwm pwm2;
 
     // Exercise
     // use defaults
-    auto servo0 = embed::rc_servo::create(pwm0);
+    auto servo0 = hal::rc_servo::create(pwm0);
     // 100Hz (or 10ms per update) with 500us being max negative start and 2500us
     // being max positive.
-    auto servo1 = embed::rc_servo::create<100, 500, 2500>(pwm1);
+    auto servo1 = hal::rc_servo::create<100, 500, 2500>(pwm1);
     pwm2.spy_configure.trigger_error_on_call(1);
-    auto servo2 = embed::rc_servo::create(pwm2);
+    auto servo2 = hal::rc_servo::create(pwm2);
 
     // Verify
     expect(bool{ servo0 });
@@ -29,7 +29,7 @@ boost::ut::suite rc_servo_test = []() {
     expect(!servo2);
   };
 
-  "embed::servo::rc_servo::position"_test = []() {
+  "hal::servo::rc_servo::position"_test = []() {
     // Setup
     constexpr auto expected0 = percent::from_ratio(5, 100);
     constexpr auto expected1 = percent::from_ratio(1, 10);
@@ -37,14 +37,14 @@ boost::ut::suite rc_servo_test = []() {
     constexpr auto expected3 = percent::from_ratio(2, 10);
     constexpr auto expected4 = percent::from_ratio(1, 4);
 
-    constexpr auto percent_neg_100 = embed::percent::from_ratio(-1, 1);
-    constexpr auto percent_neg_50 = embed::percent::from_ratio(-1, 2);
-    constexpr auto percent_0 = embed::percent::from_ratio(0, 1);
-    constexpr auto percent_50 = embed::percent::from_ratio(1, 2);
-    constexpr auto percent_100 = embed::percent::from_ratio(1, 1);
+    constexpr auto percent_neg_100 = hal::percent::from_ratio(-1, 1);
+    constexpr auto percent_neg_50 = hal::percent::from_ratio(-1, 2);
+    constexpr auto percent_0 = hal::percent::from_ratio(0, 1);
+    constexpr auto percent_50 = hal::percent::from_ratio(1, 2);
+    constexpr auto percent_100 = hal::percent::from_ratio(1, 1);
 
-    embed::mock::pwm pwm;
-    auto servo = embed::rc_servo::create<100, 500, 2500>(pwm).value();
+    hal::mock::pwm pwm;
+    auto servo = hal::rc_servo::create<100, 500, 2500>(pwm).value();
 
     // Exercise
     auto result0 = servo.position(percent_neg_100);
@@ -72,4 +72,4 @@ boost::ut::suite rc_servo_test = []() {
            std::get<0>(pwm.spy_duty_cycle.call_history().at(4)));
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/spi/mock.test.cpp
+++ b/tests/spi/mock.test.cpp
@@ -2,24 +2,23 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/spi/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite spi_mock_test = []() {
   using namespace boost::ut;
 
-  "embed::mock::write_only_spi::configure()"_test = []() {
+  "hal::mock::write_only_spi::configure()"_test = []() {
     // Setup
-    constexpr embed::spi::settings expected1 = { .clock_rate = frequency(1'000),
-                                                 .clock_idles_high = false,
-                                                 .data_valid_on_trailing_edge =
-                                                   false };
+    constexpr hal::spi::settings expected1 = { .clock_rate = frequency(1'000),
+                                               .clock_idles_high = false,
+                                               .data_valid_on_trailing_edge =
+                                                 false };
 
-    constexpr embed::spi::settings expected2 = { .clock_rate =
-                                                   frequency(10'000),
-                                                 .clock_idles_high = true,
-                                                 .data_valid_on_trailing_edge =
-                                                   true };
+    constexpr hal::spi::settings expected2 = { .clock_rate = frequency(10'000),
+                                               .clock_idles_high = true,
+                                               .data_valid_on_trailing_edge =
+                                                 true };
 
-    embed::mock::write_only_spi mock;
+    hal::mock::write_only_spi mock;
     mock.spy_configure.trigger_error_on_call(3);
 
     // Exercise + Verify
@@ -33,7 +32,7 @@ boost::ut::suite spi_mock_test = []() {
     expect(expected2 == std::get<0>(mock.spy_configure.call_history().at(2)));
   };
 
-  "embed::mock::write_only_spi::transfer()"_test = []() {
+  "hal::mock::write_only_spi::transfer()"_test = []() {
     // Setup
     constexpr std::array<const std::byte, 1> out_1{ std::byte{ 0xAA } };
     constexpr std::array<const std::byte, 2> out_2{ std::byte{ 0xDD },
@@ -41,7 +40,7 @@ boost::ut::suite spi_mock_test = []() {
     constexpr std::span<std::byte> dummy{};
     constexpr std::byte filler{ 0xFF };
 
-    embed::mock::write_only_spi mock;
+    hal::mock::write_only_spi mock;
 
     // Exercise + Verify
     expect(bool{ mock.transfer(out_1, dummy, filler) });
@@ -55,4 +54,4 @@ boost::ut::suite spi_mock_test = []() {
     expect(mock.write_record.size() == 0);
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/spi/util.test.cpp
+++ b/tests/spi/util.test.cpp
@@ -2,7 +2,7 @@
 #include <libembeddedhal/spi/util.hpp>
 #include <span>
 
-namespace embed {
+namespace hal {
 boost::ut::suite spi_util_test = []() {
   using namespace boost::ut;
 
@@ -10,7 +10,7 @@ boost::ut::suite spi_util_test = []() {
   static constexpr std::byte failure_filler{ 0x33 };
   static constexpr std::byte filler_byte{ 0xA5 };
 
-  class dummy : public embed::spi
+  class dummy : public hal::spi
   {
   public:
     [[nodiscard]] boost::leaf::result<void> driver_configure(
@@ -41,7 +41,9 @@ boost::ut::suite spi_util_test = []() {
       return {};
     }
 
-    virtual ~dummy() {}
+    virtual ~dummy()
+    {
+    }
 
     std::span<const std::byte> m_out = std::span<const std::byte>{};
     std::span<std::byte> m_in = std::span<std::byte>{};
@@ -213,4 +215,4 @@ boost::ut::suite spi_util_test = []() {
     expect(that % expected_payload.size() == spi.m_out.size());
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/static_callable.test.cpp
+++ b/tests/static_callable.test.cpp
@@ -1,7 +1,7 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/static_callable.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite static_callable_test = []() {
   using namespace boost::ut;
 

--- a/tests/static_memory_resource.test.cpp
+++ b/tests/static_memory_resource.test.cpp
@@ -1,7 +1,7 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/static_memory_resource.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite static_memory_resource_test = []() {
   using namespace boost::ut;
 };

--- a/tests/testing.test.cpp
+++ b/tests/testing.test.cpp
@@ -1,7 +1,7 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/pwm/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite testing_utilities_test = []() {
   using namespace boost::ut;
 
@@ -79,4 +79,4 @@ boost::ut::suite testing_utilities_test = []() {
   expect(that % 4 == std::get<0>(spy.call_history().at(3)));
   expect(that % 'D' == std::get<1>(spy.call_history().at(3)));
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/timeout.test.cpp
+++ b/tests/timeout.test.cpp
@@ -1,11 +1,11 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/timeout.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite timeout_test = []() {
   using namespace boost::ut;
 
-  "embed::delay(timeout)"_test = []() {
+  "hal::delay(timeout)"_test = []() {
     // Setup
     constexpr int timeout_call_limit = 10;
     int counts = 0;
@@ -20,28 +20,28 @@ boost::ut::suite timeout_test = []() {
 
     // Exercise
     // Exercise: direct
-    auto result = embed::delay<timeout_type>(timeout_function);
+    auto result = hal::delay<timeout_type>(timeout_function);
     // Exercise: Reset
     counts = 0;
     // Exercise: polymorphic
-    result = embed::delay(timeout_function);
+    result = hal::delay(timeout_function);
 
     // Verify
     expect(that % timeout_call_limit == counts);
     expect(bool{ result });
   };
 
-  "embed::delay(timeout) returns error"_test = []() {
+  "hal::delay(timeout) returns error"_test = []() {
     // Setup
     auto timeout_function = []() mutable -> boost::leaf::result<void> {
       return boost::leaf::new_error();
     };
 
     // Exercise
-    auto result = embed::delay(timeout_function);
+    auto result = hal::delay(timeout_function);
 
     // Verify
     expect(!bool{ result });
   };
 };
-}  // namespace embed
+}  // namespace hal

--- a/tests/timer/mock.test.cpp
+++ b/tests/timer/mock.test.cpp
@@ -1,12 +1,12 @@
 #include <boost/ut.hpp>
 #include <libembeddedhal/timer/mock.hpp>
 
-namespace embed {
+namespace hal {
 boost::ut::suite timer_mock_test = []() {
   using namespace boost::ut;
 
   // Setup
-  embed::mock::timer mock;
+  hal::mock::timer mock;
   const std::function<void(void)> expected_callback = []() {};
   const std::chrono::nanoseconds expected_delay = {};
 
@@ -21,4 +21,4 @@ boost::ut::suite timer_mock_test = []() {
   expect(bool{ mock.clear() });
   expect(true == std::get<0>(mock.spy_clear.call_history().at(0)));
 };
-}  // namespace embed
+}  // namespace hal


### PR DESCRIPTION
- Shorter
- Makes more contextual sense relative to the library's name