### PR TITLE
Add config::float_t

### DIFF
--- a/include/libembeddedhal/config.hpp
+++ b/include/libembeddedhal/config.hpp
@@ -7,6 +7,7 @@ namespace defaults {
 constexpr std::string_view platform = "test";
 constexpr bool on_error_callback_enabled = false;
 constexpr auto on_error_callback = []() {};
+using float_t = float;
 }  // namespace defaults
 using namespace defaults;
 }  // namespace hal::config

--- a/tests/error.test.cpp
+++ b/tests/error.test.cpp
@@ -5,6 +5,16 @@ namespace hal {
 boost::ut::suite error_test = []() {
   using namespace boost::ut;
 
+  static_assert(std::is_same_v<double, config::float_t>,
+                "For testing purposes this should be double. This is to show "
+                "that the configuration option can be overriden from the "
+                "default of 'float' to 'double'.");
+
+  static_assert(sizeof(config::float_t) == 8,
+                "For testing purposes this should be double (size 8 bytes). "
+                "This is to show that the configuration option can be "
+                "overriden from the default of 'float' to 'double'.");
+
   "[success] hal::on_error calls callback"_test = []() {
     // Setup
     auto current_call_count = config::callback_call_count;

--- a/tests/libembeddedhal.tweaks.hpp
+++ b/tests/libembeddedhal.tweaks.hpp
@@ -4,4 +4,5 @@ namespace hal::config {
 inline int callback_call_count = 0;
 constexpr bool on_error_callback_enabled = true;
 constexpr auto on_error_callback = []() { callback_call_count++; };
+using float_t = double;
 }  // namespace hal::config


### PR DESCRIPTION
The application user can use this configuration option to change the
default floating point type of the whole system.

This allows developer to choose if they want the system to default to
32-bit single precision floating point types or 64-bit double precision
floating point types. Developers may want to choose "float" as their
float type if they have a hardware FPU. If an application is run on a
target with a double precision FPU then this flag can be set to double.

Resolves #340