### PR TITLE
Doxygen: Use EXCLUDE_PATTERNS

### DIFF
--- a/docs/doxygen.conf
+++ b/docs/doxygen.conf
@@ -960,7 +960,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ../include/libhal/internal/third_party
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -976,7 +976,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */third_party/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
Previously EXCLUDE directive was used to exclude the "third_party"
directory. This required a path that included the project name within
it. This results in a break if the directory structure ever changes
like it did when the project name was changed to libhal.

Rather that using a direct link EXCLUDE_PATTERN can be used instead to
blanket exclude any "third_party" directory under the include/
directory.