### PR TITLE
Migrate from std::byte to hal::byte

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ add_test(NAME ${TEST_NAME} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 
 target_include_directories(${TEST_NAME} PUBLIC tests)
 target_compile_options(${TEST_NAME} PRIVATE -Werror -Wall -Wextra
-  -Wno-unused-function -Wconversion)
+  -Wno-unused-function -Wconversion -Wno-psabi)
 set_target_properties(${TEST_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
 target_compile_features(${TEST_NAME} PRIVATE cxx_std_20)
 set_target_properties(${TEST_NAME} PROPERTIES CXX_EXTENSIONS OFF)

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ read/sample capabilities.
 Meaning that the following code should work for all three of these functions.
 
 ```cpp
-constexpr std::byte address(0x17);
+constexpr hal::byte address(0x17);
 auto response_i2c = hal::read<1>(i2c, address);
 auto response_spi = hal::read<1>(spi);
 auto response_uart = hal::read<1>(uart);
@@ -457,11 +457,11 @@ int main() {
   // Construct the bit_bang_spi object using the implementations above
   hal::bit_bang_spi bit_bang_spi(clock, data_out, data_in);
 
-  std::array<std::byte, 4> payload = {
-    std::byte(0x11),
-    std::byte(0x22),
-    std::byte(0x33),
-    std::byte(0x44),
+  std::array<hal::byte, 4> payload = {
+    hal::byte(0x11),
+    hal::byte(0x22),
+    hal::byte(0x33),
+    hal::byte(0x44),
   };
 
   chip_select.level(false);
@@ -499,11 +499,11 @@ int main() {
 
   // Get an output_pin and have it act like a chip select
 
-  std::array<std::byte, 4> payload = {
-    std::byte(0x11),
-    std::byte(0x22),
-    std::byte(0x33),
-    std::byte(0x44),
+  std::array<hal::byte, 4> payload = {
+    hal::byte(0x11),
+    hal::byte(0x22),
+    hal::byte(0x33),
+    hal::byte(0x44),
   };
 
   chip_select.level(false);
@@ -598,8 +598,8 @@ int main()
     // error result is returned from this function the handlers below will be
     // called.
     [&i2c0]() -> status {
-      constexpr std::byte address(0x11);
-      std::array<std::byte, 1> dummy_payload{ std::byte{ 0xAA } };
+      constexpr hal::byte address(0x11);
+      std::array<hal::byte, 1> dummy_payload{ hal::byte{ 0xAA } };
       // Functions that return boost::leaf::result must have their result
       // checked and handled. To do this we use the HAL_CHECK to remove
       // the boiler plate in doing this.

--- a/include/libhal/can/interface.hpp
+++ b/include/libhal/can/interface.hpp
@@ -8,6 +8,7 @@
 
 #include "../error.hpp"
 #include "../frequency.hpp"
+#include "../units.hpp"
 
 namespace hal {
 /**
@@ -40,7 +41,7 @@ public:
     /// The number of elements in the payload
     uint8_t length = 0;
     /// The message data
-    std::array<std::byte, 8> payload{ std::byte{ 0 } };
+    std::array<hal::byte, 8> payload{ hal::byte{ 0 } };
     /// Whether or not the message is a remote request frame. If true, then
     /// length and payload are ignored.
     bool is_remote_request = false;

--- a/include/libhal/i2c/interface.hpp
+++ b/include/libhal/i2c/interface.hpp
@@ -11,6 +11,7 @@
 #include "../error.hpp"
 #include "../frequency.hpp"
 #include "../timeout.hpp"
+#include "../units.hpp"
 
 namespace hal {
 /**
@@ -57,10 +58,10 @@ public:
    * span for data_out and data_in are set to null.
    *
    * - For write transactions, pass p_data_in as an empty span
-   * `std::span<std::byte>{}` and pass a buffer to p_data_out.
+   * `std::span<hal::byte>{}` and pass a buffer to p_data_out.
    *
    * - For read transactions, pass p_data_out as an empty span
-   * `std::span<const std::byte>{}` and pass a buffer to p_data_in.
+   * `std::span<const hal::byte>{}` and pass a buffer to p_data_in.
    *
    * - For write-then-read transactions, pass a buffer for both p_data_in
    * p_data_out.
@@ -95,9 +96,9 @@ public:
    * indicated by p_timeout.
    */
   [[nodiscard]] status transaction(
-    std::byte p_address,
-    std::span<const std::byte> p_data_out,
-    std::span<std::byte> p_data_in,
+    hal::byte p_address,
+    std::span<const hal::byte> p_data_out,
+    std::span<hal::byte> p_data_in,
     std::function<hal::timeout> p_timeout) noexcept
   {
     return driver_transaction(p_address, p_data_out, p_data_in, p_timeout);
@@ -106,9 +107,9 @@ public:
 private:
   virtual status driver_configure(const settings& p_settings) noexcept = 0;
   virtual status driver_transaction(
-    std::byte p_address,
-    std::span<const std::byte> p_data_out,
-    std::span<std::byte> p_data_in,
+    hal::byte p_address,
+    std::span<const hal::byte> p_data_out,
+    std::span<hal::byte> p_data_in,
     std::function<hal::timeout> p_timeout) noexcept = 0;
 };
 /** @} */

--- a/include/libhal/i2c/util.hpp
+++ b/include/libhal/i2c/util.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 
 #include "../error.hpp"
+#include "../units.hpp"
 #include "interface.hpp"
 
 namespace hal {
@@ -26,12 +27,12 @@ namespace hal {
  */
 [[nodiscard]] inline status write(
   i2c& p_i2c,
-  std::byte p_address,
-  std::span<const std::byte> p_data_out,
+  hal::byte p_address,
+  std::span<const hal::byte> p_data_out,
   std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
   return p_i2c.transaction(
-    p_address, p_data_out, std::span<std::byte>{}, p_timeout);
+    p_address, p_data_out, std::span<hal::byte>{}, p_timeout);
 }
 /**
  * @brief read bytes from target device on i2c bus
@@ -46,12 +47,12 @@ namespace hal {
  */
 [[nodiscard]] inline status read(
   i2c& p_i2c,
-  std::byte p_address,
-  std::span<std::byte> p_data_in,
+  hal::byte p_address,
+  std::span<hal::byte> p_data_in,
   std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
   return p_i2c.transaction(
-    p_address, std::span<std::byte>{}, p_data_in, p_timeout);
+    p_address, std::span<hal::byte>{}, p_data_in, p_timeout);
 }
 /**
  * @brief return array of read bytes from target device on i2c bus
@@ -62,16 +63,16 @@ namespace hal {
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @param p_timeout - amount of time to execute the transaction
- * @return result<std::array<std::byte, BytesToRead>> - array of
+ * @return result<std::array<hal::byte, BytesToRead>> - array of
  * bytes from target device or an error.
  */
 template<size_t BytesToRead>
-[[nodiscard]] result<std::array<std::byte, BytesToRead>> read(
+[[nodiscard]] result<std::array<hal::byte, BytesToRead>> read(
   i2c& p_i2c,
-  std::byte p_address,
+  hal::byte p_address,
   std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
-  std::array<std::byte, BytesToRead> buffer;
+  std::array<hal::byte, BytesToRead> buffer;
   HAL_CHECK(read(p_i2c, p_address, buffer, p_timeout));
   return buffer;
 }
@@ -91,9 +92,9 @@ template<size_t BytesToRead>
  */
 [[nodiscard]] inline status write_then_read(
   i2c& p_i2c,
-  std::byte p_address,
-  std::span<const std::byte> p_data_out,
-  std::span<std::byte> p_data_in,
+  hal::byte p_address,
+  std::span<const hal::byte> p_data_out,
+  std::span<hal::byte> p_data_in,
   std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
   return p_i2c.transaction(p_address, p_data_out, p_data_in, p_timeout);
@@ -109,16 +110,16 @@ template<size_t BytesToRead>
  * @param p_address - target address
  * @param p_data_out - buffer of bytes to write to the target device
  * @param p_timeout - amount of time to execute the transaction
- * @return result<std::array<std::byte, BytesToRead>>
+ * @return result<std::array<hal::byte, BytesToRead>>
  */
 template<size_t BytesToRead>
-[[nodiscard]] result<std::array<std::byte, BytesToRead>> write_then_read(
+[[nodiscard]] result<std::array<hal::byte, BytesToRead>> write_then_read(
   i2c& p_i2c,
-  std::byte p_address,
-  std::span<const std::byte> p_data_out,
+  hal::byte p_address,
+  std::span<const hal::byte> p_data_out,
   std::function<hal::timeout> p_timeout = hal::never_timeout()) noexcept
 {
-  std::array<std::byte, BytesToRead> buffer;
+  std::array<hal::byte, BytesToRead> buffer;
   HAL_CHECK(write_then_read(p_i2c, p_address, p_data_out, buffer, p_timeout));
   return buffer;
 }

--- a/include/libhal/serial/interface.hpp
+++ b/include/libhal/serial/interface.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "../error.hpp"
-
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <span>
+
+#include "../error.hpp"
+#include "../units.hpp"
 
 namespace hal {
 /**
@@ -98,7 +99,7 @@ public:
    * @param p_data - data to be transmitted over the serial port
    * @return status
    */
-  [[nodiscard]] status write(std::span<const std::byte> p_data) noexcept
+  [[nodiscard]] status write(std::span<const hal::byte> p_data) noexcept
   {
     return driver_write(p_data);
   }
@@ -127,12 +128,12 @@ public:
    * buffer is greater than bytes available, then the buffer is filled up to the
    * length returned by bytes_available(). The rest of the buffer is left
    * untouched.
-   * @return result<std::span<const std::byte>> - The address will
+   * @return result<std::span<const hal::byte>> - The address will
    * ALWAYS be the same as p_data and the length will be equal to the number of
    * bytes read from the buffer.
    */
-  [[nodiscard]] result<std::span<const std::byte>> read(
-    std::span<std::byte> p_data) noexcept
+  [[nodiscard]] result<std::span<const hal::byte>> read(
+    std::span<hal::byte> p_data) noexcept
   {
     return driver_read(p_data);
   }
@@ -149,10 +150,10 @@ public:
 
 private:
   virtual status driver_configure(const settings& p_settings) noexcept = 0;
-  virtual status driver_write(std::span<const std::byte> p_data) noexcept = 0;
+  virtual status driver_write(std::span<const hal::byte> p_data) noexcept = 0;
   virtual result<size_t> driver_bytes_available() noexcept = 0;
-  virtual result<std::span<const std::byte>> driver_read(
-    std::span<std::byte> p_data) noexcept = 0;
+  virtual result<std::span<const hal::byte>> driver_read(
+    std::span<hal::byte> p_data) noexcept = 0;
   virtual status driver_flush() noexcept = 0;
 };
 /** @} */

--- a/include/libhal/serial/util.hpp
+++ b/include/libhal/serial/util.hpp
@@ -5,6 +5,7 @@
 #include <string_view>
 
 #include "../error.hpp"
+#include "../units.hpp"
 #include "interface.hpp"
 
 namespace hal {
@@ -44,7 +45,7 @@ namespace hal {
  */
 [[nodiscard]] inline status write(
   serial& p_serial,
-  std::span<const std::byte> p_data_out) noexcept
+  std::span<const hal::byte> p_data_out) noexcept
 {
   return p_serial.write(p_data_out);
 }
@@ -54,14 +55,14 @@ namespace hal {
  *
  * @param p_serial - the serial port that will be read from
  * @param p_data_in - buffer to have bytes from the serial port read into
- * @return result<std::span<const std::byte>> - return an error if
+ * @return result<std::span<const hal::byte>> - return an error if
  * a call to serial::read or delay() returns an error from the serial port or
  * a span with the number of bytes read and a pointer to where the read bytes
  * are.
  */
-[[nodiscard]] inline result<std::span<const std::byte>> read(
+[[nodiscard]] inline result<std::span<const hal::byte>> read(
   serial& p_serial,
-  std::span<std::byte> p_data_in)
+  std::span<hal::byte> p_data_in)
 {
   HAL_CHECK(delay(p_serial, p_data_in.size()));
   return p_serial.read(p_data_in);
@@ -75,16 +76,16 @@ namespace hal {
  *
  * @tparam BytesToRead - the number of bytes to be read from the serial port.
  * @param p_serial - the serial port to be read from
- * @return result<std::array<std::byte, BytesToRead>> - return an
+ * @return result<std::array<hal::byte, BytesToRead>> - return an
  * error if a call to serial::read or delay() returns an error from the
  * serial port or a span with the number of bytes read and a pointer to where
  * the read bytes are.
  */
 template<size_t BytesToRead>
-[[nodiscard]] result<std::array<std::byte, BytesToRead>> read(
+[[nodiscard]] result<std::array<hal::byte, BytesToRead>> read(
   serial& p_serial) noexcept
 {
-  std::array<std::byte, BytesToRead> buffer;
+  std::array<hal::byte, BytesToRead> buffer;
   HAL_CHECK(delay(p_serial, BytesToRead));
   HAL_CHECK(p_serial.read(buffer));
   return buffer;
@@ -104,8 +105,8 @@ template<size_t BytesToRead>
  */
 [[nodiscard]] inline status write_then_read(
   serial& p_serial,
-  std::span<const std::byte> p_data_out,
-  std::span<std::byte> p_data_in) noexcept
+  std::span<const hal::byte> p_data_out,
+  std::span<hal::byte> p_data_in) noexcept
 {
   HAL_CHECK(write(p_serial, p_data_out));
   HAL_CHECK(read(p_serial, p_data_in));
@@ -121,16 +122,16 @@ template<size_t BytesToRead>
  * @tparam BytesToRead - the number of bytes to read back
  * @param p_serial - the serial port to have the transaction occur on
  * @param p_data_out - the data to be written to the port
- * @return result<std::array<std::byte, BytesToRead>> - return an
+ * @return result<std::array<hal::byte, BytesToRead>> - return an
  * error if a call to serial::read or serial::write() returns an error from the
  * serial port or an array of read bytes.
  */
 template<size_t BytesToRead>
-[[nodiscard]] result<std::array<std::byte, BytesToRead>> write_then_read(
+[[nodiscard]] result<std::array<hal::byte, BytesToRead>> write_then_read(
   serial& p_serial,
-  std::span<const std::byte> p_data_out) noexcept
+  std::span<const hal::byte> p_data_out) noexcept
 {
-  std::array<std::byte, BytesToRead> buffer;
+  std::array<hal::byte, BytesToRead> buffer;
   HAL_CHECK(write_then_read(p_serial, p_data_out, buffer));
   return buffer;
 }

--- a/include/libhal/spi/interface.hpp
+++ b/include/libhal/spi/interface.hpp
@@ -6,6 +6,7 @@
 
 #include "../error.hpp"
 #include "../frequency.hpp"
+#include "../units.hpp"
 
 namespace hal {
 /**
@@ -42,7 +43,7 @@ public:
 
   /// Default filler data placed on the bus in place of actual write data when
   /// the write buffer has been exhausted.
-  static constexpr std::byte default_filler = std::byte{ 0xFF };
+  static constexpr hal::byte default_filler = hal::byte{ 0xFF };
 
   /**
    * @brief Configure spi to match the settings supplied
@@ -73,18 +74,18 @@ public:
    * @return status - any error that occurred during this
    * operation.
    */
-  [[nodiscard]] status transfer(std::span<const std::byte> p_data_out,
-                                std::span<std::byte> p_data_in,
-                                std::byte p_filler = default_filler) noexcept
+  [[nodiscard]] status transfer(std::span<const hal::byte> p_data_out,
+                                std::span<hal::byte> p_data_in,
+                                hal::byte p_filler = default_filler) noexcept
   {
     return driver_transfer(p_data_out, p_data_in, p_filler);
   }
 
 private:
   virtual status driver_configure(const settings& p_settings) noexcept = 0;
-  virtual status driver_transfer(std::span<const std::byte> p_data_out,
-                                 std::span<std::byte> p_data_in,
-                                 std::byte p_filler) noexcept = 0;
+  virtual status driver_transfer(std::span<const hal::byte> p_data_out,
+                                 std::span<hal::byte> p_data_in,
+                                 hal::byte p_filler) noexcept = 0;
 };
 /** @} */
 }  // namespace hal

--- a/include/libhal/spi/mock.hpp
+++ b/include/libhal/spi/mock.hpp
@@ -1,6 +1,8 @@
 
 #pragma once
+
 #include "../testing.hpp"
+#include "../units.hpp"
 #include "interface.hpp"
 
 namespace hal::mock {
@@ -29,16 +31,16 @@ struct write_only_spi : public hal::spi
   /// Spy handler for hal::spi::configure()
   spy_handler<settings> spy_configure;
   /// Record of the out data from hal::spi::transfer()
-  std::vector<std::vector<std::byte>> write_record;
+  std::vector<std::vector<hal::byte>> write_record;
 
 private:
   status driver_configure(const settings& p_settings) noexcept override
   {
     return spy_configure.record(p_settings);
   };
-  status driver_transfer(std::span<const std::byte> p_data_out,
-                         [[maybe_unused]] std::span<std::byte> p_data_in,
-                         [[maybe_unused]] std::byte p_filler) noexcept override
+  status driver_transfer(std::span<const hal::byte> p_data_out,
+                         [[maybe_unused]] std::span<hal::byte> p_data_in,
+                         [[maybe_unused]] hal::byte p_filler) noexcept override
   {
     write_record.push_back({ p_data_out.begin(), p_data_out.end() });
     return {};

--- a/include/libhal/spi/util.hpp
+++ b/include/libhal/spi/util.hpp
@@ -3,6 +3,7 @@
 #include <span>
 
 #include "../error.hpp"
+#include "../units.hpp"
 #include "interface.hpp"
 
 namespace hal {
@@ -20,10 +21,10 @@ namespace hal {
  */
 [[nodiscard]] inline status write(
   spi& p_spi,
-  std::span<const std::byte> p_data_out) noexcept
+  std::span<const hal::byte> p_data_out) noexcept
 {
   return p_spi.transfer(
-    p_data_out, std::span<std::byte>{}, spi::default_filler);
+    p_data_out, std::span<hal::byte>{}, spi::default_filler);
 }
 
 /**
@@ -39,10 +40,10 @@ namespace hal {
  */
 [[nodiscard]] inline status read(
   spi& p_spi,
-  std::span<std::byte> p_data_in,
-  std::byte p_filler = spi::default_filler) noexcept
+  std::span<hal::byte> p_data_in,
+  hal::byte p_filler = spi::default_filler) noexcept
 {
-  return p_spi.transfer(std::span<std::byte>{}, p_data_in, p_filler);
+  return p_spi.transfer(std::span<hal::byte>{}, p_data_in, p_filler);
 }
 /**
  * @brief Read data from the SPI bus and return a std::array of bytes.
@@ -53,16 +54,16 @@ namespace hal {
  * @param p_spi - spi driver
  * @param p_filler - filler data placed on the bus in place of actual write
  * data.
- * @return result<std::array<std::byte, BytesToRead>> - any errors
+ * @return result<std::array<hal::byte, BytesToRead>> - any errors
  * associated with this call
  */
 template<size_t BytesToRead>
-[[nodiscard]] result<std::array<std::byte, BytesToRead>> read(
+[[nodiscard]] result<std::array<hal::byte, BytesToRead>> read(
   spi& p_spi,
-  std::byte p_filler = spi::default_filler) noexcept
+  hal::byte p_filler = spi::default_filler) noexcept
 {
-  std::array<std::byte, BytesToRead> buffer;
-  HAL_CHECK(p_spi.transfer(std::span<std::byte>{}, buffer, p_filler));
+  std::array<hal::byte, BytesToRead> buffer;
+  HAL_CHECK(p_spi.transfer(std::span<hal::byte>{}, buffer, p_filler));
   return buffer;
 }
 
@@ -87,9 +88,9 @@ template<size_t BytesToRead>
  */
 [[nodiscard]] inline status write_then_read(
   spi& p_spi,
-  std::span<const std::byte> p_data_out,
-  std::span<std::byte> p_data_in,
-  std::byte p_filler = spi::default_filler) noexcept
+  std::span<const hal::byte> p_data_out,
+  std::span<hal::byte> p_data_in,
+  hal::byte p_filler = spi::default_filler) noexcept
 {
   HAL_CHECK(write(p_spi, p_data_out));
   HAL_CHECK(read(p_spi, p_data_in, p_filler));
@@ -106,13 +107,13 @@ template<size_t BytesToRead>
  * @param p_data_out - bytes to write to the bus
  * @param p_filler - filler data placed on the bus when the read operation
  * begins.
- * @return result<std::array<std::byte, BytesToRead>>
+ * @return result<std::array<hal::byte, BytesToRead>>
  */
 template<size_t BytesToRead>
-[[nodiscard]] result<std::array<std::byte, BytesToRead>> write_then_read(
+[[nodiscard]] result<std::array<hal::byte, BytesToRead>> write_then_read(
   spi& p_spi,
-  std::span<const std::byte> p_data_out,
-  std::byte p_filler = spi::default_filler) noexcept
+  std::span<const hal::byte> p_data_out,
+  hal::byte p_filler = spi::default_filler) noexcept
 {
   HAL_CHECK(write(p_spi, p_data_out));
   return read<BytesToRead>(p_spi, p_filler);

--- a/include/libhal/static_memory_resource.hpp
+++ b/include/libhal/static_memory_resource.hpp
@@ -3,6 +3,8 @@
 #include <cstddef>
 #include <memory_resource>
 
+#include "units.hpp"
+
 namespace hal {
 /**
  * @addtogroup utility
@@ -86,7 +88,7 @@ protected:
     // allocated address must contain a valid address from buffer. To get the
     // location of the unallocated memory, simply add the number of bytes to
     // allocate_address variable.
-    m_unallocated_memory = static_cast<std::byte*>(allocated_address) + p_bytes;
+    m_unallocated_memory = static_cast<hal::byte*>(allocated_address) + p_bytes;
 
     return allocated_address;
   }
@@ -119,8 +121,8 @@ protected:
   }
 
 private:
-  std::array<std::byte, BufferSize> m_buffer{};
-  std::byte* m_unallocated_memory{};
+  std::array<hal::byte, BufferSize> m_buffer{};
+  hal::byte* m_unallocated_memory{};
   std::pmr::monotonic_buffer_resource m_resource{};
 };
 /** @} */

--- a/include/libhal/units.hpp
+++ b/include/libhal/units.hpp
@@ -13,5 +13,9 @@ namespace hal {
 /// within an std::int32_t integer.
 using time_duration = std::chrono::duration<std::int32_t, std::micro>;
 
+/// Standard type for bytes in libhal. hal::byte has a number of annoyances that
+/// results in more verbose code without much benefit and thus hal::byte was
+/// created.
+using byte = std::uint8_t;
 /** @} */
 }  // namespace hal

--- a/tests/i2c/util.test.cpp
+++ b/tests/i2c/util.test.cpp
@@ -6,9 +6,9 @@ namespace hal {
 boost::ut::suite i2c_util_test = []() {
   using namespace boost::ut;
 
-  static constexpr std::byte successful_address{ 0x15 };
-  static constexpr std::byte failure_address{ 0x33 };
-  static constexpr std::byte filler_byte{ 0xA5 };
+  static constexpr hal::byte successful_address{ 0x15 };
+  static constexpr hal::byte failure_address{ 0x33 };
+  static constexpr hal::byte filler_byte{ 0xA5 };
 
   struct test_timeout_t
   {
@@ -28,9 +28,9 @@ boost::ut::suite i2c_util_test = []() {
       return {};
     }
     [[nodiscard]] status driver_transaction(
-      std::byte p_address,
-      std::span<const std::byte> p_out,
-      std::span<std::byte> p_in,
+      hal::byte p_address,
+      std::span<const hal::byte> p_out,
+      std::span<hal::byte> p_in,
       std::function<hal::timeout> p_timeout) noexcept override
     {
       m_address = p_address;
@@ -52,16 +52,16 @@ boost::ut::suite i2c_util_test = []() {
     {
     }
 
-    std::byte m_address = std::byte{ 0 };
-    std::span<const std::byte> m_out = std::span<const std::byte>{};
-    std::span<std::byte> m_in = std::span<std::byte>{};
+    hal::byte m_address = hal::byte{ 0 };
+    std::span<const hal::byte> m_out = std::span<const hal::byte>{};
+    std::span<hal::byte> m_in = std::span<hal::byte>{};
   };
 
   "[success] write"_test = []() {
     // Setup
     test_i2c i2c;
     test_timeout_t test_timeout;
-    const std::array<std::byte, 4> expected_payload{};
+    const std::array<hal::byte, 4> expected_payload{};
 
     // Exercise
     auto result =
@@ -82,7 +82,7 @@ boost::ut::suite i2c_util_test = []() {
     // Setup
     test_i2c i2c;
     test_timeout_t test_timeout;
-    const std::array<std::byte, 4> expected_payload{};
+    const std::array<hal::byte, 4> expected_payload{};
 
     // Exercise
     auto result =
@@ -103,7 +103,7 @@ boost::ut::suite i2c_util_test = []() {
     // Setup
     test_i2c i2c;
     test_timeout_t test_timeout;
-    std::array<std::byte, 4> expected_buffer;
+    std::array<hal::byte, 4> expected_buffer;
 
     // Exercise
     auto result =
@@ -124,7 +124,7 @@ boost::ut::suite i2c_util_test = []() {
     // Setup
     test_i2c i2c;
     test_timeout_t test_timeout;
-    std::array<std::byte, 4> expected_buffer;
+    std::array<hal::byte, 4> expected_buffer;
 
     // Exercise
     auto result =
@@ -145,7 +145,7 @@ boost::ut::suite i2c_util_test = []() {
     // Setup
     test_i2c i2c;
     test_timeout_t test_timeout;
-    std::array<std::byte, 5> expected_buffer;
+    std::array<hal::byte, 5> expected_buffer;
     expected_buffer.fill(filler_byte);
 
     // Exercise
@@ -184,8 +184,8 @@ boost::ut::suite i2c_util_test = []() {
     // Setup
     test_i2c i2c;
     test_timeout_t test_timeout;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer;
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer;
 
     // Exercise
     auto result = write_then_read(i2c,
@@ -209,8 +209,8 @@ boost::ut::suite i2c_util_test = []() {
     // Setup
     test_i2c i2c;
     test_timeout_t test_timeout;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer;
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer;
     expected_buffer.fill(filler_byte);
 
     // Exercise
@@ -235,8 +235,8 @@ boost::ut::suite i2c_util_test = []() {
     // Setup
     test_i2c i2c;
     test_timeout_t test_timeout;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer{};
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer{};
     expected_buffer.fill(filler_byte);
 
     // Exercise
@@ -259,7 +259,7 @@ boost::ut::suite i2c_util_test = []() {
     // Setup
     test_i2c i2c;
     test_timeout_t test_timeout;
-    const std::array<std::byte, 4> expected_payload{};
+    const std::array<hal::byte, 4> expected_payload{};
 
     // Exercise
     auto result = write_then_read<5>(

--- a/tests/serial/util.test.cpp
+++ b/tests/serial/util.test.cpp
@@ -7,9 +7,9 @@ boost::ut::suite serial_util_test = []() {
   using namespace boost::ut;
   using namespace std::chrono_literals;
 
-  // static constexpr std::byte success_filler{ 0xF5 };
-  static constexpr std::byte write_failure_byte{ 0x33 };
-  static constexpr std::byte filler_byte{ 0xA5 };
+  // static constexpr hal::byte success_filler{ 0xF5 };
+  static constexpr hal::byte write_failure_byte{ 0x33 };
+  static constexpr hal::byte filler_byte{ 0xA5 };
 
   class dummy : public hal::serial
   {
@@ -19,7 +19,7 @@ boost::ut::suite serial_util_test = []() {
       return {};
     }
     [[nodiscard]] status driver_write(
-      std::span<const std::byte> p_data) noexcept override
+      std::span<const hal::byte> p_data) noexcept override
     {
       if (p_data[0] == write_failure_byte) {
         return boost::leaf::new_error();
@@ -36,8 +36,8 @@ boost::ut::suite serial_util_test = []() {
       return ++m_bytes_available;
     }
 
-    [[nodiscard]] result<std::span<const std::byte>> driver_read(
-      std::span<std::byte> p_data) noexcept override
+    [[nodiscard]] result<std::span<const hal::byte>> driver_read(
+      std::span<hal::byte> p_data) noexcept override
     {
       if (m_read_fails) {
         return boost::leaf::new_error();
@@ -57,8 +57,8 @@ boost::ut::suite serial_util_test = []() {
     {
     }
 
-    std::span<const std::byte> m_out{};
-    std::span<std::byte> m_in{};
+    std::span<const hal::byte> m_out{};
+    std::span<hal::byte> m_in{};
     size_t m_bytes_available = 0;
     bool m_flush_called = false;
     bool m_bytes_available_fails = false;
@@ -68,7 +68,7 @@ boost::ut::suite serial_util_test = []() {
   "[success] write"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{};
+    const std::array<hal::byte, 4> expected_payload{};
 
     // Exercise
     auto result = write(serial, expected_payload);
@@ -87,7 +87,7 @@ boost::ut::suite serial_util_test = []() {
   "[failure] write"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{ write_failure_byte };
+    const std::array<hal::byte, 4> expected_payload{ write_failure_byte };
 
     // Exercise
     auto result = write(serial, expected_payload);
@@ -106,7 +106,7 @@ boost::ut::suite serial_util_test = []() {
   "[success] read"_test = []() {
     // Setup
     dummy serial;
-    std::array<std::byte, 4> expected_buffer;
+    std::array<hal::byte, 4> expected_buffer;
 
     // Exercise
     auto result = read(serial, expected_buffer);
@@ -125,7 +125,7 @@ boost::ut::suite serial_util_test = []() {
   "[failure bytes_available] read"_test = []() {
     // Setup
     dummy serial;
-    std::array<std::byte, 4> expected_buffer;
+    std::array<hal::byte, 4> expected_buffer;
     serial.m_bytes_available_fails = true;
 
     // Exercise
@@ -145,7 +145,7 @@ boost::ut::suite serial_util_test = []() {
   "[failure read] read"_test = []() {
     // Setup
     dummy serial;
-    std::array<std::byte, 4> expected_buffer;
+    std::array<hal::byte, 4> expected_buffer;
     serial.m_read_fails = true;
 
     // Exercise
@@ -165,7 +165,7 @@ boost::ut::suite serial_util_test = []() {
   "[success] read<Length>"_test = []() {
     // Setup
     dummy serial;
-    std::array<std::byte, 5> expected_buffer;
+    std::array<hal::byte, 5> expected_buffer;
     expected_buffer.fill(filler_byte);
 
     // Exercise
@@ -222,8 +222,8 @@ boost::ut::suite serial_util_test = []() {
   "[success] write_then_read"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer;
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer;
 
     // Exercise
     auto result = write_then_read(serial, expected_payload, expected_buffer);
@@ -241,8 +241,8 @@ boost::ut::suite serial_util_test = []() {
   "[failure bytes_available] write_then_read"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer;
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer;
     expected_buffer.fill(filler_byte);
     serial.m_bytes_available_fails = true;
 
@@ -263,8 +263,8 @@ boost::ut::suite serial_util_test = []() {
   "[failure read] write_then_read"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer;
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer;
     expected_buffer.fill(filler_byte);
     serial.m_read_fails = true;
 
@@ -285,8 +285,8 @@ boost::ut::suite serial_util_test = []() {
   "[failure on write] write_then_read"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{ write_failure_byte };
-    std::array<std::byte, 4> expected_buffer;
+    const std::array<hal::byte, 4> expected_payload{ write_failure_byte };
+    std::array<hal::byte, 4> expected_buffer;
 
     // Exercise
     auto result = write_then_read(serial, expected_payload, expected_buffer);
@@ -305,8 +305,8 @@ boost::ut::suite serial_util_test = []() {
   "[success] write_then_read<Length>"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer{};
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer{};
     expected_buffer.fill(filler_byte);
 
     // Exercise
@@ -326,7 +326,7 @@ boost::ut::suite serial_util_test = []() {
   "[failure on write] write_then_read<Length>"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{ write_failure_byte };
+    const std::array<hal::byte, 4> expected_payload{ write_failure_byte };
 
     // Exercise
     auto result = write_then_read<5>(serial, expected_payload);
@@ -345,7 +345,7 @@ boost::ut::suite serial_util_test = []() {
   "[failure bytes_available] write_then_read<Length>"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{};
+    const std::array<hal::byte, 4> expected_payload{};
     serial.m_bytes_available_fails = true;
 
     // Exercise
@@ -365,7 +365,7 @@ boost::ut::suite serial_util_test = []() {
   "[failure read] write_then_read<Length>"_test = []() {
     // Setup
     dummy serial;
-    const std::array<std::byte, 4> expected_payload{};
+    const std::array<hal::byte, 4> expected_payload{};
     serial.m_read_fails = true;
 
     // Exercise

--- a/tests/spi/mock.test.cpp
+++ b/tests/spi/mock.test.cpp
@@ -34,11 +34,11 @@ boost::ut::suite spi_mock_test = []() {
 
   "hal::mock::write_only_spi::transfer()"_test = []() {
     // Setup
-    constexpr std::array<const std::byte, 1> out_1{ std::byte{ 0xAA } };
-    constexpr std::array<const std::byte, 2> out_2{ std::byte{ 0xDD },
-                                                    std::byte{ 0xCC } };
-    constexpr std::span<std::byte> dummy{};
-    constexpr std::byte filler{ 0xFF };
+    constexpr std::array<const hal::byte, 1> out_1{ hal::byte{ 0xAA } };
+    constexpr std::array<const hal::byte, 2> out_2{ hal::byte{ 0xDD },
+                                                    hal::byte{ 0xCC } };
+    constexpr std::span<hal::byte> dummy{};
+    constexpr hal::byte filler{ 0xFF };
 
     hal::mock::write_only_spi mock;
 

--- a/tests/spi/util.test.cpp
+++ b/tests/spi/util.test.cpp
@@ -6,9 +6,9 @@ namespace hal {
 boost::ut::suite spi_util_test = []() {
   using namespace boost::ut;
 
-  static constexpr std::byte success_filler{ 0xF5 };
-  static constexpr std::byte failure_filler{ 0x33 };
-  static constexpr std::byte filler_byte{ 0xA5 };
+  static constexpr hal::byte success_filler{ 0xF5 };
+  static constexpr hal::byte failure_filler{ 0x33 };
+  static constexpr hal::byte filler_byte{ 0xA5 };
 
   class dummy : public hal::spi
   {
@@ -17,9 +17,9 @@ boost::ut::suite spi_util_test = []() {
     {
       return {};
     }
-    [[nodiscard]] status driver_transfer(std::span<const std::byte> p_out,
-                                         std::span<std::byte> p_in,
-                                         std::byte p_filler) noexcept override
+    [[nodiscard]] status driver_transfer(std::span<const hal::byte> p_out,
+                                         std::span<hal::byte> p_in,
+                                         hal::byte p_filler) noexcept override
     {
       if (!p_out.empty()) {
         m_out = p_out;
@@ -43,15 +43,15 @@ boost::ut::suite spi_util_test = []() {
     {
     }
 
-    std::span<const std::byte> m_out = std::span<const std::byte>{};
-    std::span<std::byte> m_in = std::span<std::byte>{};
-    std::byte m_filler = std::byte{ 0xFF };
+    std::span<const hal::byte> m_out = std::span<const hal::byte>{};
+    std::span<hal::byte> m_in = std::span<hal::byte>{};
+    hal::byte m_filler = hal::byte{ 0xFF };
   };
 
   "[success] write"_test = []() {
     // Setup
     dummy spi;
-    const std::array<std::byte, 4> expected_payload{};
+    const std::array<hal::byte, 4> expected_payload{};
 
     // Exercise
     auto result = write(spi, expected_payload);
@@ -68,7 +68,7 @@ boost::ut::suite spi_util_test = []() {
   "[success] read"_test = []() {
     // Setup
     dummy spi;
-    std::array<std::byte, 4> expected_buffer;
+    std::array<hal::byte, 4> expected_buffer;
 
     // Exercise
     auto result = read(spi, expected_buffer, success_filler);
@@ -86,7 +86,7 @@ boost::ut::suite spi_util_test = []() {
   "[failure] read"_test = []() {
     // Setup
     dummy spi;
-    std::array<std::byte, 4> expected_buffer;
+    std::array<hal::byte, 4> expected_buffer;
 
     // Exercise
     auto result = read(spi, expected_buffer, failure_filler);
@@ -104,7 +104,7 @@ boost::ut::suite spi_util_test = []() {
   "[success] read<Length>"_test = []() {
     // Setup
     dummy spi;
-    std::array<std::byte, 5> expected_buffer;
+    std::array<hal::byte, 5> expected_buffer;
     expected_buffer.fill(filler_byte);
 
     // Exercise
@@ -138,8 +138,8 @@ boost::ut::suite spi_util_test = []() {
   "[success] write_then_read"_test = []() {
     // Setup
     dummy spi;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer;
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer;
 
     // Exercise
     auto result =
@@ -158,8 +158,8 @@ boost::ut::suite spi_util_test = []() {
   "[failure] write_then_read"_test = []() {
     // Setup
     dummy spi;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer;
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer;
     expected_buffer.fill(filler_byte);
 
     // Exercise
@@ -179,8 +179,8 @@ boost::ut::suite spi_util_test = []() {
   "[success] write_then_read<Length>"_test = []() {
     // Setup
     dummy spi;
-    const std::array<std::byte, 4> expected_payload{};
-    std::array<std::byte, 4> expected_buffer{};
+    const std::array<hal::byte, 4> expected_payload{};
+    std::array<hal::byte, 4> expected_buffer{};
     expected_buffer.fill(filler_byte);
 
     // Exercise
@@ -200,7 +200,7 @@ boost::ut::suite spi_util_test = []() {
   "[failure] write_then_read<Length>"_test = []() {
     // Setup
     dummy spi;
-    const std::array<std::byte, 4> expected_payload{};
+    const std::array<hal::byte, 4> expected_payload{};
 
     // Exercise
     auto result = write_then_read<5>(spi, expected_payload, failure_filler);


### PR DESCRIPTION
hal::byte is simply a std::uint8_t alias.

Resolves #371