### PR TITLE
Add units as config::float aliases

### DIFF
--- a/include/libhal/units.hpp
+++ b/include/libhal/units.hpp
@@ -3,6 +3,8 @@
 #include <chrono>
 #include <cstdint>
 
+#include "config.hpp"
+
 namespace hal {
 /**
  * @addtogroup utility
@@ -17,5 +19,58 @@ using time_duration = std::chrono::duration<std::int32_t, std::micro>;
 /// results in more verbose code without much benefit and thus hal::byte was
 /// created.
 using byte = std::uint8_t;
+
+/// Type for frequency represented in hertz
+using hertz = config::float_type;
+
+/// Type for acceleration represented in the force applied by gravity at sea
+/// level.
+using g_force = config::float_type;
+
+/// Type for length represented in meters.
+using meters = config::float_type;
+
+// Namespace containing user defined literals for the hal standard units
+namespace experimental::literals {
+[[nodiscard]] consteval hertz operator""_Hz(unsigned long long p_value) noexcept
+{
+  return static_cast<config::float_type>(p_value);
+}
+[[nodiscard]] consteval hertz operator""_kHz(
+  unsigned long long p_value) noexcept
+{
+  return static_cast<config::float_type>(p_value) * std::kilo::num;
+}
+[[nodiscard]] consteval hertz operator""_MHz(
+  unsigned long long p_value) noexcept
+{
+  return static_cast<config::float_type>(p_value) * std::mega::num;
+}
+[[nodiscard]] consteval g_force operator""_g(
+  unsigned long long p_value) noexcept
+{
+  return static_cast<config::float_type>(p_value);
+}
+[[nodiscard]] consteval meters operator""_um(
+  unsigned long long p_value) noexcept
+{
+  return static_cast<config::float_type>(p_value) / std::micro::den;
+}
+[[nodiscard]] consteval meters operator""_mm(
+  unsigned long long p_value) noexcept
+{
+  return static_cast<config::float_type>(p_value) / std::milli::den;
+}
+[[nodiscard]] consteval meters operator""_m(unsigned long long p_value) noexcept
+{
+  return static_cast<config::float_type>(p_value);
+}
+[[nodiscard]] consteval meters operator""_km(
+  unsigned long long p_value) noexcept
+{
+  return static_cast<config::float_type>(p_value) * std::kilo::num;
+}
+}  // namespace experimental::literals
+
 /** @} */
 }  // namespace hal


### PR DESCRIPTION
Migrating the codebase to simple use floats (or percentage where
applicable) for units. This would mean that there will be no compile
time checks or conversion when it comes to units. The units are merely
annotations to help better document what parameters are what, but
underneath they are simply floats.

This way we can see how users use these units and what patterns can be
introduced to make conversion easier or disallow certain catastrophic
errors. Going forward, these types, if they were to evolve, will need to
be implicitly convertable to floats as to not break future code, which
introduces safety concerns, but seems to be the middle ground between
using plain old floats and strongly typed units which made working with
them burdensome, cumbersome, confusing, and slow.

Issue #230