### PR TITLE
Remove templates from interfaces

### DIFF
--- a/include/libhal/adc/interface.hpp
+++ b/include/libhal/adc/interface.hpp
@@ -18,35 +18,30 @@ namespace hal {
  * Use this interface for devices and peripherals that can convert analog
  * voltage signals into a digital number.
  *
+ * This interface makes no assumptions about how the conversation is made via
+ * the ADC. Conversions could be performed at each call of this function.
+ * Conversions can be ongoing by hardware and this function returns the latest
+ * sample or the first sample from a queue. Collecting samples can occur
+ * over a communication protocol like SPI or I2C.
  */
-template<std::floating_point float_t = config::float_type>
 class adc
 {
 public:
   /**
    * @brief Read a sample from the analog to digital converter.
    *
-   * This function makes no assumptions about how the conversation is made via
-   * the ADC. Conversions could be performed at each call of this function.
-   * Conversions can be ongoing by hardware and this function returns the latest
-   * sample or the first sample from a queue. The conversation can also occur
-   * over a communication protocol like SPI or I2C which could effect the time
-   * it takes for this function to return. It is the responsibility of the
-   * application developer to understand how a particular ADC will effect their
-   * application.
-   *
-   * @return result<percent> - Return the value of the
-   * ADC as a full_scale value. Typical implementation for a 12-bit adc would
-   * look like: `return hal::bit_depth<uint32_t, 12>(adc_value);`.
-   *
+   * @return result<percent> - percentage of the voltage from Vss to Vcc, where
+   * Vss is the negative or ground reference for the ADC and Vcc is the positive
+   * or supply voltage for the ADC. For example with a Vss of 0V and Vcc of 4V,
+   * a reading of 0.5 would represent 2V.
    */
-  [[nodiscard]] result<percentage<float_t>> read() noexcept
+  [[nodiscard]] result<percentage> read() noexcept
   {
     return driver_read();
   }
 
 private:
-  virtual result<percentage<float_t>> driver_read() noexcept = 0;
+  virtual result<percentage> driver_read() noexcept = 0;
 };
 /** @} */
 }  // namespace hal

--- a/include/libhal/adc/mock.hpp
+++ b/include/libhal/adc/mock.hpp
@@ -12,32 +12,31 @@ namespace hal::mock {
 /**
  * @brief Mock adc implementation for use in unit tests and simulations.
  */
-template<std::floating_point float_t = config::float_type>
-struct adc : public hal::adc<float_t>
+struct adc : public hal::adc
 {
   /**
    * @brief Queues the percentages to be returned for read()
    *
    * @param p_adc_values - queue of percentages
    */
-  void set(std::queue<percentage<float_t>>& p_adc_values)
+  void set(std::queue<percentage>& p_adc_values)
   {
     m_adc_values = p_adc_values;
   }
 
 private:
-  result<percentage<float_t>> driver_read() noexcept
+  result<percentage> driver_read() noexcept
   {
     if (m_adc_values.size() == 0) {
       return boost::leaf::new_error(
         std::out_of_range("percentages queue is empty!"));
     }
-    percentage<float_t> m_current_value = m_adc_values.front();
+    percentage m_current_value = m_adc_values.front();
     m_adc_values.pop();
     return m_current_value;
   }
 
-  std::queue<percentage<float_t>> m_adc_values{};
+  std::queue<percentage> m_adc_values{};
 };
 /** @} */
 }  // namespace hal::mock

--- a/include/libhal/dac/interface.hpp
+++ b/include/libhal/dac/interface.hpp
@@ -19,7 +19,6 @@ namespace hal {
  * analog voltages between a defined LOW and HIGH voltage.
  *
  */
-template<std::floating_point float_t = config::float_type>
 class dac
 {
 public:
@@ -34,13 +33,13 @@ public:
    * @return status - any error that occurred during this
    * operation.
    */
-  [[nodiscard]] status write(percentage<float_t> p_value) noexcept
+  [[nodiscard]] status write(percentage p_value) noexcept
   {
     return driver_write(p_value);
   }
 
 private:
-  virtual status driver_write(percentage<float_t> p_value) noexcept = 0;
+  virtual status driver_write(percentage p_value) noexcept = 0;
 };
 /** @} */
 }  // namespace hal

--- a/include/libhal/dac/mock.hpp
+++ b/include/libhal/dac/mock.hpp
@@ -13,8 +13,7 @@ namespace hal::mock {
  * spy function for write()
  *
  */
-template<std::floating_point float_t = config::float_type>
-struct dac : public hal::dac<float_t>
+struct dac : public hal::dac
 {
   /**
    * @brief Reset spy information for write()
@@ -26,10 +25,10 @@ struct dac : public hal::dac<float_t>
   }
 
   /// Spy handler for hal::dac::write()
-  spy_handler<percentage<float_t>> spy_write;
+  spy_handler<percentage> spy_write;
 
 private:
-  status driver_write(percentage<float_t> p_value) noexcept override
+  status driver_write(percentage p_value) noexcept override
   {
     return spy_write.record(p_value);
   };

--- a/include/libhal/frequency.hpp
+++ b/include/libhal/frequency.hpp
@@ -79,13 +79,14 @@ struct duty_cycle
    * count.
    */
   template<std::floating_point float_t>
-  [[nodiscard]] explicit constexpr operator percentage<float_t>() const noexcept
+  [[nodiscard]] explicit constexpr operator percentage_t<float_t>()
+    const noexcept
   {
     auto float_high = static_cast<float>(high);
     auto float_low = static_cast<float>(low);
     auto float_total = float_high + float_low;
     auto ratio = float_high / float_total;
-    return percentage<float_t>(ratio);
+    return percentage_t<float_t>(ratio);
   }
 
   /**
@@ -97,7 +98,7 @@ struct duty_cycle
   template<std::floating_point float_t>
   [[nodiscard]] explicit constexpr operator float_t() const noexcept
   {
-    return static_cast<float_t>(static_cast<percentage<float_t>>((*this)));
+    return static_cast<float_t>(static_cast<percentage_t<float_t>>((*this)));
   }
 };
 

--- a/include/libhal/motor/interface.hpp
+++ b/include/libhal/motor/interface.hpp
@@ -21,7 +21,6 @@ namespace hal {
  *   - A servo with open loop motor control
  *
  */
-template<std::floating_point float_t = config::float_type>
 class motor
 {
 public:
@@ -56,13 +55,13 @@ public:
    * @return status - success or an error that occurred when
    * attempting to set the power output of the motor.
    */
-  [[nodiscard]] status power(percentage<float_t> p_power) noexcept
+  [[nodiscard]] status power(percentage p_power) noexcept
   {
     return driver_power(p_power);
   }
 
 private:
-  virtual status driver_power(percentage<float_t> p_power) noexcept = 0;
+  virtual status driver_power(percentage p_power) noexcept = 0;
 };
 /** @} */
 }  // namespace hal

--- a/include/libhal/motor/mock.hpp
+++ b/include/libhal/motor/mock.hpp
@@ -13,8 +13,7 @@ namespace hal::mock {
  * spy function for power()
  *
  */
-template<std::floating_point float_t = config::float_type>
-struct motor : public hal::motor<float_t>
+struct motor : public hal::motor
 {
   /**
    * @brief Reset spy information for power()
@@ -26,10 +25,10 @@ struct motor : public hal::motor<float_t>
   }
 
   /// Spy handler for hal::motor::write()
-  spy_handler<percentage<float_t>> spy_power;
+  spy_handler<percentage> spy_power;
 
 private:
-  status driver_power(percentage<float_t> p_power) noexcept override
+  status driver_power(percentage p_power) noexcept override
   {
     return spy_power.record(p_power);
   };

--- a/include/libhal/percentage.hpp
+++ b/include/libhal/percentage.hpp
@@ -15,39 +15,40 @@ namespace hal {
  *
  * @tparam float_t - floating point representation
  */
-template<std::floating_point float_t = float>
-class percentage
+template<std::floating_point float_t>
+class percentage_t
 {
 public:
   constexpr static float_t max = +1.0;
   constexpr static float_t min = -1.0;
   constexpr static float_t zero = 0.0;
 
-  constexpr percentage(float_t p_value)
+  template<std::floating_point U>
+  constexpr percentage_t(U p_value)
     : m_value(0.0)
   {
+    set_and_constrain(static_cast<float_t>(p_value));
+  }
+  constexpr percentage_t& operator=(const percentage_t& p_percent)
+  {
+    m_value = p_percent.value();
+    return *this;
+  }
+  constexpr percentage_t& operator=(const percentage_t&& p_percent)
+  {
+    m_value = p_percent.value();
+    return *this;
+  }
+  constexpr percentage_t& operator=(float_t p_value)
+  {
     set_and_constrain(p_value);
-  }
-  constexpr percentage& operator=(const percentage& p_percent)
-  {
-    m_value = p_percent.value();
     return *this;
   }
-  constexpr percentage& operator=(const percentage&& p_percent)
-  {
-    m_value = p_percent.value();
-    return *this;
-  }
-  constexpr percentage& operator=(float_t p_value)
-  {
-    set_and_constrain(p_value);
-    return *this;
-  }
-  constexpr percentage(const percentage& p_percent)
+  constexpr percentage_t(const percentage_t& p_percent)
   {
     m_value = p_percent.value();
   }
-  constexpr percentage(const percentage&& p_percent)
+  constexpr percentage_t(const percentage_t&& p_percent)
   {
     m_value = p_percent.value();
   }
@@ -63,12 +64,12 @@ public:
   {
     return static_cast<float>(m_value);
   }
-  constexpr bool equals(percentage p_other, float_t p_epsilon = 1e-9f) const
+  constexpr bool equals(percentage_t p_other, float_t p_epsilon = 1e-9f) const
   {
     return hal::equals(m_value, p_other.value(), p_epsilon);
   }
-  constexpr bool operator<=>(const percentage& p_percent) const = default;
-  constexpr bool operator==(const percentage& p_percent) const
+  constexpr bool operator<=>(const percentage_t& p_percent) const = default;
+  constexpr bool operator==(const percentage_t& p_percent) const
   {
     return equals(p_percent);
   }
@@ -80,4 +81,6 @@ private:
   }
   float_t m_value{ 0.0 };
 };
+
+using percentage = percentage_t<float>;
 }  // namespace hal

--- a/include/libhal/pwm/interface.hpp
+++ b/include/libhal/pwm/interface.hpp
@@ -43,7 +43,6 @@ namespace hal {
  * signals to servos, sending telemetry and much more.
  *
  */
-template<std::floating_point float_t = config::float_type>
 class pwm
 {
 public:
@@ -66,15 +65,14 @@ public:
    * @param p_duty_cycle - set the duty cycle of the pwm.
    * @return status - status of this operation
    */
-  [[nodiscard]] status duty_cycle(percentage<float_t> p_duty_cycle) noexcept
+  [[nodiscard]] status duty_cycle(percentage p_duty_cycle) noexcept
   {
     return driver_duty_cycle(p_duty_cycle);
   }
 
 private:
   virtual status driver_frequency(hertz p_frequency) noexcept = 0;
-  virtual status driver_duty_cycle(
-    percentage<float_t> p_duty_cycle) noexcept = 0;
+  virtual status driver_duty_cycle(percentage p_duty_cycle) noexcept = 0;
 };
 /** @} */
 }  // namespace hal

--- a/include/libhal/pwm/mock.hpp
+++ b/include/libhal/pwm/mock.hpp
@@ -13,8 +13,7 @@ namespace hal::mock {
  * functions for frequency() and duty_cycle().
  *
  */
-template<std::floating_point float_t = config::float_type>
-struct pwm : public hal::pwm<float_t>
+struct pwm : public hal::pwm
 {
   /**
    * @brief Reset spy information for both frequency() and duty_cycle()
@@ -29,14 +28,14 @@ struct pwm : public hal::pwm<float_t>
   /// Spy handler for hal::pwm::frequency()
   spy_handler<hertz> spy_frequency;
   /// Spy handler for hal::pwm::duty_cycle()
-  spy_handler<percentage<float_t>> spy_duty_cycle;
+  spy_handler<percentage> spy_duty_cycle;
 
 private:
   status driver_frequency(hertz p_settings) noexcept override
   {
     return spy_frequency.record(p_settings);
   }
-  status driver_duty_cycle(percentage<float_t> p_duty_cycle) noexcept override
+  status driver_duty_cycle(percentage p_duty_cycle) noexcept override
   {
     return spy_duty_cycle.record(p_duty_cycle);
   }

--- a/include/libhal/servo/interface.hpp
+++ b/include/libhal/servo/interface.hpp
@@ -35,7 +35,6 @@ namespace hal {
  *     commanded to move to their center position, they will be able to move to
  *     that position no matter the original position of the rotor at power on.
  */
-template<std::floating_point float_t = config::float_type>
 class servo
 {
 public:
@@ -90,13 +89,13 @@ public:
    * @param p_position - position to move the servo to
    * @return status - success or error flag
    */
-  [[nodiscard]] status position(percentage<float_t> p_position) noexcept
+  [[nodiscard]] status position(percentage p_position) noexcept
   {
     return driver_position(p_position);
   }
 
 private:
-  virtual status driver_position(percentage<float_t> p_position) noexcept = 0;
+  virtual status driver_position(percentage p_position) noexcept = 0;
 };
 /** @} */
 }  // namespace hal

--- a/include/libhal/servo/mock.hpp
+++ b/include/libhal/servo/mock.hpp
@@ -13,8 +13,7 @@ namespace hal::mock {
  * simulations.
  *
  */
-template<std::floating_point float_t = config::float_type>
-struct servo : public hal::servo<float_t>
+struct servo : public hal::servo
 {
   /**
    * @brief Reset spy information for position()
@@ -26,10 +25,10 @@ struct servo : public hal::servo<float_t>
   }
 
   /// Spy handler for hal::servo::position()
-  spy_handler<percentage<float_t>> spy_position;
+  spy_handler<percentage> spy_position;
 
 private:
-  status driver_position(percentage<float_t> p_position) noexcept override
+  status driver_position(percentage p_position) noexcept override
   {
     return spy_position.record(p_position);
   }

--- a/include/libhal/servo/rc.hpp
+++ b/include/libhal/servo/rc.hpp
@@ -14,8 +14,7 @@ namespace hal {
  * @brief Generic RC servo driver.
  *
  */
-template<std::floating_point float_t = config::float_type>
-class rc_servo : public hal::servo<float_t>
+class rc_servo : public hal::servo
 {
 public:
   /**
@@ -34,7 +33,7 @@ public:
   template<uint32_t Frequency = 50,
            uint32_t MinMicroseconds = 1000,
            uint32_t MaxMicroseconds = 2000>
-  static result<rc_servo> create(hal::pwm<float_t>& p_pwm)
+  static result<rc_servo> create(hal::pwm& p_pwm)
   {
     // Check that MinMicroseconds is less than MaxMicroseconds
     static_assert(
@@ -49,8 +48,8 @@ public:
     HAL_CHECK(p_pwm.frequency(frequency));
 
     auto wavelength = (1.0f / frequency) * std::micro::den;
-    auto min_percent = percentage<float_t>(MinMicroseconds / wavelength);
-    auto max_percent = percentage<float_t>(MaxMicroseconds / wavelength);
+    auto min_percent = percentage(MinMicroseconds / wavelength);
+    auto max_percent = percentage(MaxMicroseconds / wavelength);
     auto percent_range =
       std::make_pair(min_percent.value(), max_percent.value());
 
@@ -58,25 +57,24 @@ public:
   }
 
 private:
-  constexpr rc_servo(hal::pwm<float_t>& p_pwm,
-                     std::pair<float_t, float_t> p_percent_range)
+  constexpr rc_servo(hal::pwm& p_pwm, std::pair<float, float> p_percent_range)
     : m_pwm(&p_pwm)
     , m_percent_range(p_percent_range)
   {
   }
 
-  status driver_position(percentage<float_t> p_position) noexcept override
+  status driver_position(percentage p_position) noexcept override
   {
-    auto scaled_percent_raw = map(p_position.value(),
-                                  std::make_pair(hal::percentage<float_t>::min,
-                                                 hal::percentage<float_t>::max),
-                                  m_percent_range);
-    auto scaled_percent = percentage<float_t>(scaled_percent_raw);
+    auto scaled_percent_raw =
+      map(p_position.value(),
+          std::make_pair(hal::percentage::min, hal::percentage::max),
+          m_percent_range);
+    auto scaled_percent = percentage(scaled_percent_raw);
     return m_pwm->duty_cycle(scaled_percent);
   }
 
-  hal::pwm<float_t>* m_pwm;
-  std::pair<float_t, float_t> m_percent_range;
+  hal::pwm* m_pwm;
+  std::pair<float, float> m_percent_range;
 };
 /** @} */
 }  // namespace hal

--- a/tests/adc/mock.test.cpp
+++ b/tests/adc/mock.test.cpp
@@ -8,9 +8,9 @@ boost::ut::suite adc_mock_test = []() {
   using namespace boost::ut;
 
   // Setup
-  auto expected1 = percentage<config::float_type>(0.25);
-  auto expected2 = percentage<config::float_type>(0.5);
-  auto expected3 = percentage<config::float_type>(1.0);
+  auto expected1 = percentage(0.25);
+  auto expected2 = percentage(0.5);
+  auto expected3 = percentage(1.0);
   hal::mock::adc mock;
   std::deque percentages{ expected1, expected2, expected3 };
   std::queue queue(percentages);

--- a/tests/dac/mock.test.cpp
+++ b/tests/dac/mock.test.cpp
@@ -7,8 +7,8 @@ boost::ut::suite dac_mock_test = []() {
 
   // Setup
   hal::mock::dac mock;
-  constexpr auto expected1 = percentage<config::float_type>(0.5);
-  constexpr auto expected2 = percentage<config::float_type>(0.25);
+  constexpr auto expected1 = percentage(0.5);
+  constexpr auto expected2 = percentage(0.25);
   mock.spy_write.trigger_error_on_call(3);
 
   // Exercise + Verify

--- a/tests/motor/mock.test.cpp
+++ b/tests/motor/mock.test.cpp
@@ -7,8 +7,8 @@ boost::ut::suite motor_mock_test = []() {
 
   // Setup
   hal::mock::motor mock;
-  constexpr auto expected1 = percentage<config::float_type>(0.5);
-  constexpr auto expected2 = percentage<config::float_type>(0.25);
+  constexpr auto expected1 = percentage(0.5);
+  constexpr auto expected2 = percentage(0.25);
   mock.spy_power.trigger_error_on_call(3);
 
   // Exercise + Verify

--- a/tests/ostreams.hpp
+++ b/tests/ostreams.hpp
@@ -40,7 +40,7 @@ inline std::ostream& operator<<(std::ostream& os, const percent& p_percent)
 }
 template<std::floating_point float_t>
 inline std::ostream& operator<<(std::ostream& os,
-                                const percentage<float_t>& p_percent)
+                                const percentage_t<float_t>& p_percent)
 {
   return (os << "percentage { " << std::fixed << std::setprecision(15)
              << static_cast<float>(p_percent.value()) << " : " << std::right

--- a/tests/percentage.test.cpp
+++ b/tests/percentage.test.cpp
@@ -6,57 +6,57 @@ namespace hal {
 boost::ut::suite percentage_test = []() {
   using namespace boost::ut;
 
-  "hal::percentage"_test = []() {
+  "hal::percentage_t"_test = []() {
     "ctor: zero"_test = []() {
-      expect(that % 0.0_d == hal::percentage(0.0).value());
-      expect(that % 0.0_f == hal::percentage(0.0f).value());
-      hal::percentage<double> assign_double = 0.0;
+      expect(that % 0.0_d == hal::percentage_t<double>(0.0).value());
+      expect(that % 0.0_f == hal::percentage_t<float>(0.0f).value());
+      hal::percentage_t<double> assign_double = 0.0;
       expect(that % 0.0_d == assign_double.value());
-      hal::percentage<float> assign_float = 0.0f;
+      hal::percentage_t<float> assign_float = 0.0f;
       expect(that % 0.0_f == assign_float.value());
     };
 
     "ctor: standard"_test = []() {
-      expect(that % 0.222_d == hal::percentage(0.222).value());
-      expect(that % 0.123_d == hal::percentage(0.123).value());
-      expect(that % 0.875_d == hal::percentage(0.875).value());
-      expect(that % 0.999_d == hal::percentage(0.999).value());
-      expect(that % 0.347_d == hal::percentage(0.347).value());
+      expect(that % 0.222_d == hal::percentage_t<double>(0.222).value());
+      expect(that % 0.123_d == hal::percentage_t<double>(0.123).value());
+      expect(that % 0.875_d == hal::percentage_t<double>(0.875).value());
+      expect(that % 0.999_d == hal::percentage_t<double>(0.999).value());
+      expect(that % 0.347_d == hal::percentage_t<double>(0.347).value());
     };
 
     "ctor: out of bounds"_test = []() {
-      expect(that % 1.0_d == hal::percentage(1.5).value());
-      expect(that % -1.0_d == hal::percentage(-1.5).value());
-      expect(that % 1.0_f == hal::percentage(1.5f).value());
-      expect(that % -1.0_f == hal::percentage(-1.5f).value());
-      constexpr hal::percentage<double> assign_double = 1.5;
+      expect(that % 1.0_d == hal::percentage_t<double>(1.5).value());
+      expect(that % -1.0_d == hal::percentage_t<double>(-1.5).value());
+      expect(that % 1.0_f == hal::percentage_t<float>(1.5f).value());
+      expect(that % -1.0_f == hal::percentage_t<float>(-1.5f).value());
+      constexpr hal::percentage_t<double> assign_double = 1.5;
       expect(that % 1.0_d == assign_double.value());
       static_assert(1.0f == assign_double.value());
-      constexpr hal::percentage<float> assign_float = 1.5f;
+      constexpr hal::percentage_t<float> assign_float = 1.5f;
       expect(that % 1.0_f == assign_float.value());
       static_assert(1.0f == assign_float.value());
-      constexpr hal::percentage<double> assign_double_neg = -1.5;
+      constexpr hal::percentage_t<double> assign_double_neg = -1.5;
       expect(that % -1.0_d == assign_double_neg.value());
       static_assert(-1.0 == assign_double_neg.value());
-      constexpr hal::percentage<float> assign_float_neg = -1.5f;
+      constexpr hal::percentage_t<float> assign_float_neg = -1.5f;
       expect(that % -1.0_f == assign_float_neg.value());
       static_assert(-1.0f == assign_float_neg.value());
     };
 
     "const assignment"_test = []() {
-      constexpr hal::percentage<double> assign_double = 1.5;
-      hal::percentage<double> assign_double2 = assign_double;
+      constexpr hal::percentage_t<double> assign_double = 1.5;
+      hal::percentage_t<double> assign_double2 = assign_double;
       expect(that % assign_double.value() == assign_double2.value());
     };
     "const copy"_test = []() {
-      constexpr hal::percentage<double> assign_double = 1.5;
-      hal::percentage<double> assign_double2(assign_double);
+      constexpr hal::percentage_t<double> assign_double = 1.5;
+      hal::percentage_t<double> assign_double2(assign_double);
       expect(that % assign_double.value() == assign_double2.value());
     };
     "const equals zero"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.0f);
-      constexpr auto value2 = hal::percentage<float>(0.1f - 0.1f);
+      constexpr auto value1 = hal::percentage_t<float>(0.0f);
+      constexpr auto value2 = hal::percentage_t<float>(0.1f - 0.1f);
       constexpr auto epsilon = 0.000001f;
 
       // Exercise + verify
@@ -64,8 +64,8 @@ boost::ut::suite percentage_test = []() {
     };
     "const equals boundaries"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.2f + 0.8f);
-      constexpr auto value2 = hal::percentage<float>(0.5F + 0.5f);
+      constexpr auto value1 = hal::percentage_t<float>(0.2f + 0.8f);
+      constexpr auto value2 = hal::percentage_t<float>(0.5F + 0.5f);
       constexpr auto epsilon = 0.000001f;
 
       // Exercise + verify
@@ -73,8 +73,8 @@ boost::ut::suite percentage_test = []() {
     };
     "const equals standard"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.15f + 0.15f);
-      constexpr auto value2 = hal::percentage<float>(0.2f + 0.1f);
+      constexpr auto value1 = hal::percentage_t<float>(0.15f + 0.15f);
+      constexpr auto value2 = hal::percentage_t<float>(0.2f + 0.1f);
       constexpr auto epsilon = 0.000001f;
 
       // Exercise + verify
@@ -82,24 +82,24 @@ boost::ut::suite percentage_test = []() {
     };
     "const equals standard default epsilon"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.15f + 0.15f);
-      constexpr auto value2 = hal::percentage<float>(0.2f + 0.1f);
+      constexpr auto value1 = hal::percentage_t<float>(0.15f + 0.15f);
+      constexpr auto value2 = hal::percentage_t<float>(0.2f + 0.1f);
 
       // Exercise + verify
       expect(value1.equals(value2));
     };
     "const equals standard default epsilon not equal"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.3f);
-      constexpr auto value2 = hal::percentage<float>(0.4f);
+      constexpr auto value1 = hal::percentage_t<float>(0.3f);
+      constexpr auto value2 = hal::percentage_t<float>(0.4f);
 
       // Exercise + verify
       expect(false == value1.equals(value2));
     };
     "const equals standard double"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<double>(0.15 + 0.15);
-      constexpr auto value2 = hal::percentage<double>(0.2 + 0.1);
+      constexpr auto value1 = hal::percentage_t<double>(0.15 + 0.15);
+      constexpr auto value2 = hal::percentage_t<double>(0.2 + 0.1);
       constexpr auto epsilon = 0.000001;
 
       // Exercise + verify
@@ -107,8 +107,8 @@ boost::ut::suite percentage_test = []() {
     };
     "const equals standard not equal"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.3f);
-      constexpr auto value2 = hal::percentage<float>(0.4f);
+      constexpr auto value1 = hal::percentage_t<float>(0.3f);
+      constexpr auto value2 = hal::percentage_t<float>(0.4f);
       constexpr auto epsilon = 0.000001f;
 
       // Exercise + verify
@@ -116,48 +116,48 @@ boost::ut::suite percentage_test = []() {
     };
     "operator== zero"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.0f);
-      constexpr auto value2 = hal::percentage<float>(0.1f - 0.1f);
+      constexpr auto value1 = hal::percentage_t<float>(0.0f);
+      constexpr auto value2 = hal::percentage_t<float>(0.1f - 0.1f);
 
       // Exercise + verify
       expect(value1 == value2);
     };
     "operator== boundaries"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.2f + 0.8f);
-      constexpr auto value2 = hal::percentage<float>(0.5F + 0.5f);
+      constexpr auto value1 = hal::percentage_t<float>(0.2f + 0.8f);
+      constexpr auto value2 = hal::percentage_t<float>(0.5F + 0.5f);
 
       // Exercise + verify
       expect(value1 == value2);
     };
     "operator== standard"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.15f + 0.15f);
-      constexpr auto value2 = hal::percentage<float>(0.2f + 0.1f);
+      constexpr auto value1 = hal::percentage_t<float>(0.15f + 0.15f);
+      constexpr auto value2 = hal::percentage_t<float>(0.2f + 0.1f);
 
       // Exercise + verify
       expect(value1 == value2);
     };
     "operator== standard"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<double>(0.15 + 0.15);
-      constexpr auto value2 = hal::percentage<double>(0.2 + 0.1);
+      constexpr auto value1 = hal::percentage_t<double>(0.15 + 0.15);
+      constexpr auto value2 = hal::percentage_t<double>(0.2 + 0.1);
 
       // Exercise + verify
       expect(value1 == value2);
     };
     "operator== standard not equal"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.3f);
-      constexpr auto value2 = hal::percentage<float>(0.4f);
+      constexpr auto value1 = hal::percentage_t<float>(0.3f);
+      constexpr auto value2 = hal::percentage_t<float>(0.4f);
 
       // Exercise + verify
       expect(value1 != value2);
     };
     "operator== standard not equal"_test = []() {
       // Setup
-      constexpr auto value1 = hal::percentage<float>(0.3001f);
-      constexpr auto value2 = hal::percentage<float>(0.3002f);
+      constexpr auto value1 = hal::percentage_t<float>(0.3001f);
+      constexpr auto value2 = hal::percentage_t<float>(0.3002f);
 
       // Exercise + verify
       expect(value1 != value2);

--- a/tests/pwm/mock.test.cpp
+++ b/tests/pwm/mock.test.cpp
@@ -25,8 +25,8 @@ boost::ut::suite pwm_mock_test = []() {
 
   "hal::mock::pwm::duty_cycle()"_test = []() {
     // Setup
-    constexpr auto expected1 = percentage<config::float_type>(0.5);
-    constexpr auto expected2 = percentage<config::float_type>(0.25);
+    constexpr auto expected1 = percentage(0.5);
+    constexpr auto expected2 = percentage(0.25);
     hal::mock::pwm mock;
     mock.spy_duty_cycle.trigger_error_on_call(3);
 

--- a/tests/servo/interface.test.cpp
+++ b/tests/servo/interface.test.cpp
@@ -5,16 +5,15 @@
 
 namespace hal {
 namespace {
-constexpr auto expected_value = percentage<config::float_type>(0.5);
+constexpr auto expected_value = percentage(0.5);
 
-template<std::floating_point float_t = config::float_type>
-class test_servo : public hal::servo<float_t>
+class test_servo : public hal::servo
 {
 public:
   float_t m_passed_position;
 
 private:
-  status driver_position(percentage<float_t> p_position) noexcept override
+  status driver_position(percentage p_position) noexcept override
   {
     m_passed_position = p_position.value();
     return {};
@@ -25,7 +24,7 @@ private:
 boost::ut::suite servo_test = []() {
   using namespace boost::ut;
   // Setup
-  test_servo<config::float_type> test;
+  test_servo test;
 
   // Exercise
   auto result = test.position(expected_value);

--- a/tests/servo/mock.test.cpp
+++ b/tests/servo/mock.test.cpp
@@ -8,8 +8,8 @@ boost::ut::suite servo_mock_test = []() {
   "hal::mock::servo::position()"_test = []() {
     // Setup
     hal::mock::servo mock;
-    auto expected1 = percentage<config::float_type>(0.5);
-    auto expected2 = percentage<config::float_type>(0.25);
+    auto expected1 = percentage(0.5);
+    auto expected2 = percentage(0.25);
 
     // Exercise
     auto result1 = mock.position(expected1);

--- a/tests/servo/rc.test.cpp
+++ b/tests/servo/rc.test.cpp
@@ -16,12 +16,12 @@ boost::ut::suite rc_servo_test = []() {
 
     // Exercise
     // use defaults
-    auto servo0 = hal::rc_servo<>::create(pwm0);
+    auto servo0 = hal::rc_servo::create(pwm0);
     // 100Hz (or 10ms per update) with 500us being max negative start and 2500us
     // being max positive.
-    auto servo1 = hal::rc_servo<>::create<100, 500, 2500>(pwm1);
+    auto servo1 = hal::rc_servo::create<100, 500, 2500>(pwm1);
     pwm2.spy_frequency.trigger_error_on_call(1);
-    auto servo2 = hal::rc_servo<>::create(pwm2);
+    auto servo2 = hal::rc_servo::create(pwm2);
 
     // Verify
     expect(bool{ servo0 });
@@ -31,18 +31,18 @@ boost::ut::suite rc_servo_test = []() {
 
   "hal::servo::rc_servo::position"_test = []() {
     // Setup
-    constexpr auto expected0 = percentage<config::float_type>(0.05);
-    constexpr auto expected1 = percentage<config::float_type>(0.10);
-    constexpr auto expected2 = percentage<config::float_type>(0.20);
-    constexpr auto expected3 = percentage<config::float_type>(0.25);
+    constexpr auto expected0 = percentage(0.05);
+    constexpr auto expected1 = percentage(0.10);
+    constexpr auto expected2 = percentage(0.20);
+    constexpr auto expected3 = percentage(0.25);
 
-    constexpr auto percent_neg_100 = percentage<config::float_type>(-1.0);
-    constexpr auto percent_neg_50 = percentage<config::float_type>(-0.5);
-    constexpr auto percent_50 = percentage<config::float_type>(0.5);
-    constexpr auto percent_100 = percentage<config::float_type>(1.0);
+    constexpr auto percent_neg_100 = percentage(-1.0);
+    constexpr auto percent_neg_50 = percentage(-0.5);
+    constexpr auto percent_50 = percentage(0.5);
+    constexpr auto percent_100 = percentage(1.0);
 
     hal::mock::pwm pwm;
-    auto servo = hal::rc_servo<>::create<100, 500, 2500>(pwm).value();
+    auto servo = hal::rc_servo::create<100, 500, 2500>(pwm).value();
 
     // Exercise
     auto result0 = servo.position(percent_neg_100);


### PR DESCRIPTION
The added templates create space for added complexity where it wasn't
before for a very small subset of situations. It is better to have the
base interfaces be simple and support the majority of use cases and
provide more advanced interfaces for more complicated or specific use
cases. Most ADCs are 24 bits and below in precision. A double floating
point ADC percentage is only necessary above that range and thus, if it
is needed a `hal::precision_adc` can be introduced. The same goes for
all other interfaces.

- Rename hal::percentage to hal::percentage_t
- hal::percentage is an alias for type percentage<float>