### PR TITLE
Update various interfaces

### DIFF
--- a/include/libhal/i2c/interface.hpp
+++ b/include/libhal/i2c/interface.hpp
@@ -37,7 +37,8 @@ public:
   struct settings
   {
     /// @brief The serial clock rate in hertz.
-    hertz clock_rate{};
+    std::uint32_t clock_rate = 100'000;
+
     /**
      * @brief Default operators for <, <=, >, >= and ==
      *

--- a/include/libhal/i2c/minimum_speed.hpp
+++ b/include/libhal/i2c/minimum_speed.hpp
@@ -15,7 +15,7 @@ namespace hal {
 class minimum_speed_i2c : public hal::i2c
 {
 public:
-  constexpr static auto default_max_speed = hertz(2'000'000);
+  constexpr static auto default_max_speed = 2'000'000;
   /**
    * @brief Factory function to create minimum_speed_i2c object.
    *
@@ -39,7 +39,7 @@ private:
 
   status driver_configure(const settings& p_new_setting) noexcept override
   {
-    if (equals(p_new_setting.clock_rate, 0.0)) {
+    if (p_new_setting.clock_rate == 0) {
       return hal::new_error(std::errc::invalid_argument);
     }
     if (m_lowest_seen_frequency > p_new_setting.clock_rate) {

--- a/include/libhal/input_pin/interface.hpp
+++ b/include/libhal/input_pin/interface.hpp
@@ -37,7 +37,7 @@ public:
    * @brief Configure the input pin to match the settings supplied
    *
    * @param p_settings - settings to apply to input pin
-   * @return status - success or failure
+   * @return status
    * @throws std::errc::invalid_argument if the settings could not be achieved.
    */
   [[nodiscard]] status configure(const settings& p_settings) noexcept
@@ -48,8 +48,8 @@ public:
   /**
    * @brief Read the state of the input pin
    *
-   * @return result<bool> - true indicates HIGH voltage and false
-   * indicates LOW voltage
+   * @return result<bool> - true indicates HIGH voltage level and false
+   * indicates LOW voltage level
    */
   [[nodiscard]] result<bool> level() noexcept
   {

--- a/include/libhal/interrupt_pin/mock.hpp
+++ b/include/libhal/interrupt_pin/mock.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <queue>
-#include <stdexcept>
-
 #include "../testing.hpp"
 #include "interface.hpp"
 
@@ -19,59 +16,30 @@ namespace hal::mock {
 struct interrupt_pin : public hal::interrupt_pin
 {
   /**
-   * @brief Reset spy information for configure(), attach_interrupt(), and
-   * detach_interrupt()
+   * @brief Reset spy information for configure(), on_trigger(), and
+   * disable()
    *
    */
   void reset()
   {
     spy_configure.reset();
-    spy_attach_interrupt.reset();
-    spy_detach_interrupt.reset();
-  }
-  /**
-   * @brief Queues the active levels to be returned for level()
-   *
-   * @param p_levels - queue of actives levels
-   */
-  void set(std::queue<bool>& p_levels)
-  {
-    m_levels = p_levels;
+    spy_on_trigger.reset();
   }
 
   /// Spy handler for hal::interrupt_pin::configure()
   spy_handler<settings> spy_configure;
-  /// Spy handler for hal::interrupt_pin::attach_interrupt()
-  spy_handler<std::function<void(void)>, trigger_edge> spy_attach_interrupt;
-  /// Spy handler for hal::interrupt_pin::detach_interrupt()
-  spy_handler<bool> spy_detach_interrupt;
+  /// Spy handler for hal::interrupt_pin::on_trigger()
+  spy_handler<std::function<handler>> spy_on_trigger;
 
 private:
   status driver_configure(const settings& p_settings) noexcept override
   {
     return spy_configure.record(p_settings);
   }
-  result<bool> driver_level() noexcept override
+  void driver_on_trigger(std::function<handler> p_callback) noexcept override
   {
-    if (m_levels.size() == 0) {
-      return hal::new_error(
-        std::out_of_range("interrupt pin level queue is empty!"));
-    }
-    bool m_current_value = m_levels.front();
-    m_levels.pop();
-    return m_current_value;
+    [[maybe_unused]] auto result = spy_on_trigger.record(p_callback);
   }
-  status driver_attach_interrupt(std::function<void(void)> p_callback,
-                                 trigger_edge p_trigger) noexcept override
-  {
-    return spy_attach_interrupt.record(p_callback, p_trigger);
-  }
-  status driver_detach_interrupt() noexcept override
-  {
-    return spy_detach_interrupt.record(true);
-  }
-
-  std::queue<bool> m_levels{};
 };
 /** @} */
 }  // namespace hal::mock

--- a/include/libhal/motor/interface.hpp
+++ b/include/libhal/motor/interface.hpp
@@ -11,10 +11,10 @@ namespace hal {
  * @{
  */
 /**
- * @brief Hardware abstraction for open loop continuous rotary and linear
- * actuators.
+ * @brief Open loop motorized actuator hardware abstraction
  *
  * The motor interface can represent a variety of things such as:
+ *
  *   - A driver for motor controller IC like the DRV8801
  *   - A driver for a motor with integrated controller & serial interface
  *   - A unidirectional motor controlled by a single transistor
@@ -25,8 +25,7 @@ class motor
 {
 public:
   /**
-   * @brief Apply a percentage of power to the motor equal to the `p_power`
-   * input parameter.
+   * @brief Apply power to the motor
    *
    * Power is a percentage and thus cannot be used as a way to gauge how fast
    * the motor is moving. In general applying more power means to increase speed

--- a/include/libhal/output_pin/interface.hpp
+++ b/include/libhal/output_pin/interface.hpp
@@ -15,6 +15,9 @@ namespace hal {
  * Use this to drive a pin HIGH or LOW in order to send a control signal or turn
  * off or on an LED.
  *
+ * Implementations of this interface can be backed by external devices such as
+ * I/O expanders or other microcontrollers.
+ *
  */
 class output_pin
 {
@@ -25,12 +28,10 @@ public:
     /// Pull resistor for the pin. This generally only helpful when open
     /// drain is enabled.
     pin_resistor resistor = pin_resistor::pull_up;
+
     /// Starting level of the output pin. HIGH voltage defined as true and LOW
     /// voltage defined as false.
     bool open_drain = false;
-    /// Set the starting level of the output pin on initialization. HIGH voltage
-    /// defined as true and LOW voltage defined as false.
-    bool starting_level = true;
 
     /**
      * @brief Default operators for <, <=, >, >= and ==
@@ -52,25 +53,27 @@ public:
   {
     return driver_configure(p_settings);
   }
+
   /**
    * @brief Set the state of the pin
    *
    * @param p_high - if true then the pin state is set to HIGH voltage. If
    * false, the pin state is set to LOW voltage.
    * @return status - success or failure
-   * operation.
    */
   [[nodiscard]] status level(bool p_high) noexcept
   {
     return driver_level(p_high);
   }
+
   /**
-   * @brief Read the state of the output pin. Implementations must read the pin
-   * state from hardware and will not simply cache the results from running
-   * level(bool).
+   * @brief Read the current state of the output pin
    *
-   * @return result<bool> - true indicates HIGH voltage and false
-   * indicates LOW voltage
+   * Implementations must read the pin state from hardware and will not simply
+   * cache the results from the execution of `level(bool)`.
+   *
+   * @return result<bool> - true indicates HIGH voltage and false indicates LOW
+   * voltage
    */
   [[nodiscard]] result<bool> level() noexcept
   {

--- a/include/libhal/serial/interface.hpp
+++ b/include/libhal/serial/interface.hpp
@@ -73,6 +73,14 @@ public:
     stop_bits stop = stop_bits::one;
     /// Parity bit type for each frame
     parity parity = parity::none;
+
+    /**
+     * @brief Default operators for <, <=, >, >= and ==
+     *
+     * @return auto - result of the comparison
+     */
+    [[nodiscard]] constexpr auto operator<=>(const settings&) const noexcept =
+      default;
   };
 
   /// Structure informing the caller of the number of bytes that can be read out

--- a/include/libhal/servo/interface.hpp
+++ b/include/libhal/servo/interface.hpp
@@ -70,21 +70,21 @@ public:
    *
    *     // This is a made up servo has 180 degrees of movement and has absolute
    *     // positioning.
-   *     hal::example_servo servo;  // implements hal::servo
+   *     hal::example_servo servo;
    *     // Move to center position
-   *     servo.position(hal::percent::from_ratio(0, 90));
+   *     servo.position(hal::percentage(0.0/90.0));
    *     // ... delay ...
    *     // Move to the +45 degrees position
-   *     servo.position(hal::percent::from_ratio(45, 90));
+   *     servo.position(hal::percentage(45.0/90.0));
    *     // ... delay ...
    *     // Move to the -45 degrees position
-   *     servo.position(hal::percent::from_ratio(-45, 90));
+   *     servo.position(hal::percentage(-45.0/90.0));
    *     // ... delay ...
    *     // Move to the -90 degrees position
-   *     servo.position(hal::percent::from_ratio(-90, 90));
+   *     servo.position(hal::percentage(-90.0/90.0));
    *     // ... delay ...
    *     // Move to the +90 degrees position
-   *     servo.position(hal::percent::from_ratio(90, 90));
+   *     servo.position(hal::percentage(90.0/90.0));
    *
    * @param p_position - position to move the servo to
    * @return status - success or failure

--- a/include/libhal/spi/interface.hpp
+++ b/include/libhal/spi/interface.hpp
@@ -24,8 +24,8 @@ public:
   /// Generic settings for a standard SPI device.
   struct settings
   {
-    /// Serial clock frequency
-    hertz clock_rate{};
+    /// Serial clock frequency in hertz
+    std::uint32_t clock_rate = 100'000;
     /// The polarity of the pins when the signal is idle
     bool clock_idles_high = false;
     /// The phase of the clock signal when communicating
@@ -71,7 +71,6 @@ public:
    * @param p_filler - filler data placed on the bus in place of actual write
    * data when p_data_out has been exhausted.
    * @return status - success or failure
-   * operation.
    */
   [[nodiscard]] status transfer(std::span<const hal::byte> p_data_out,
                                 std::span<hal::byte> p_data_in,

--- a/include/libhal/timer/interface.hpp
+++ b/include/libhal/timer/interface.hpp
@@ -64,6 +64,7 @@ public:
   {
     return driver_is_running();
   }
+
   /**
    * @brief Stops a scheduled event from happening.
    *
@@ -80,6 +81,7 @@ public:
   {
     return driver_clear();
   }
+
   /**
    * @brief Schedule an callback to be called at a designated time/interval
    *
@@ -90,7 +92,7 @@ public:
    * @param p_callback - callback function to be called when the timer expires
    * @param p_delay - the amount of time before the timer expires
    * @return status - success or failure
-   * `delay_too_large` if p_interval cannot be reached.
+   * @throws out_of_bounds - if p_interval cannot be achieved.
    */
   [[nodiscard]] status schedule(std::function<void(void)> p_callback,
                                 std::chrono::nanoseconds p_delay) noexcept

--- a/tests/i2c/minimum_speed.test.cpp
+++ b/tests/i2c/minimum_speed.test.cpp
@@ -48,11 +48,10 @@ boost::ut::suite minimum_speed_test = []() {
       constexpr hal::i2c::settings minimum_default = {
         .clock_rate = minimum_speed_i2c::default_max_speed
       };
-      constexpr hal::i2c::settings expected_upper_boundary = {
-        .clock_rate = hertz(3'000'000)
-      };
-      constexpr hal::i2c::settings expected_lower = { .clock_rate = hertz(1) };
-      constexpr hal::i2c::settings expected_zero = { .clock_rate = hertz(0) };
+      constexpr hal::i2c::settings expected_upper_boundary = { .clock_rate =
+                                                                 3'000'000 };
+      constexpr hal::i2c::settings expected_lower = { .clock_rate = 1 };
+      constexpr hal::i2c::settings expected_zero = { .clock_rate = 0 };
 
       // Exercise
       auto mock = hal::minimum_speed_i2c::create(mock_i2c);
@@ -74,14 +73,13 @@ boost::ut::suite minimum_speed_test = []() {
     "create() + configure() with frequency"_test = []() {
       // Setup
       hal::fake_i2c mock_i2c;
-      constexpr hal::hertz device_frequency = hertz(1'000'000);
+      constexpr std::uint32_t device_frequency = 1'000'000;
       constexpr hal::i2c::settings choosen_frequency = { .clock_rate =
                                                            device_frequency };
-      constexpr hal::i2c::settings expected_upper_boundary = {
-        .clock_rate = hertz(3'000'000)
-      };
-      constexpr hal::i2c::settings expected_lower = { .clock_rate = hertz(1) };
-      constexpr hal::i2c::settings expected_zero = { .clock_rate = hertz(0) };
+      constexpr hal::i2c::settings expected_upper_boundary = { .clock_rate =
+                                                                 3'000'000 };
+      constexpr hal::i2c::settings expected_lower = { .clock_rate = 1 };
+      constexpr hal::i2c::settings expected_zero = { .clock_rate = 0 };
 
       // Exercise
       auto mock = hal::minimum_speed_i2c::create(mock_i2c, device_frequency);

--- a/tests/interrupt_pin/mock.test.cpp
+++ b/tests/interrupt_pin/mock.test.cpp
@@ -12,6 +12,7 @@ boost::ut::suite interrupt_pin_mock_test = []() {
     constexpr hal::interrupt_pin::settings mock_settings_default{};
     constexpr hal::interrupt_pin::settings mock_settings_custom{
       .resistor = pin_resistor::pull_down,
+      .trigger = interrupt_pin::trigger_edge::rising,
     };
     hal::mock::interrupt_pin mock;
 
@@ -27,80 +28,48 @@ boost::ut::suite interrupt_pin_mock_test = []() {
     expect(mock_settings_custom.resistor ==
            std::get<0>(mock.spy_configure.call_history().at(1)).resistor);
   };
-  "hal::mock::interrupt_pin::set() + level()"_test = []() {
+  "hal::mock::interrupt_pin::on_trigger()"_test = []() {
     // Setup
-    hal::mock::interrupt_pin mock;
-    std::deque inputs{ true, false, true };
-    std::queue queue(inputs);
-
-    // Exercise
-    mock.set(queue);
-
-    // Verify
-    expect(that % true == mock.level().value());
-    expect(that % false == mock.level().value());
-    expect(that % true == mock.level().value());
-    expect(throws([&mock] { mock.level().value(); }));
-  };
-  "hal::mock::interrupt_pin::detach_interrupt()"_test = []() {
-    // Setup
+    int counter = 0;
+    const std::function<void(bool)> expected_callback = [&counter](bool) {
+      counter++;
+    };
     hal::mock::interrupt_pin mock;
 
     // Exercise
-    (void)mock.detach_interrupt();
+    mock.on_trigger(expected_callback);
+    mock.on_trigger(expected_callback);
+    mock.on_trigger(expected_callback);
+    auto callback1 = std::get<0>(mock.spy_on_trigger.call_history().at(0));
+    auto callback2 = std::get<0>(mock.spy_on_trigger.call_history().at(1));
+    auto callback3 = std::get<0>(mock.spy_on_trigger.call_history().at(2));
 
     // Verify
-    expect(that % true ==
-           std::get<0>(mock.spy_detach_interrupt.call_history().at(0)));
-  };
-  "hal::mock::interrupt_pin::attach_interrupt()"_test = []() {
-    // Setup
-    const std::function<void(void)> expected_callback = []() {};
-    const hal::interrupt_pin::trigger_edge expected_falling =
-      hal::interrupt_pin::trigger_edge::falling;
-    const hal::interrupt_pin::trigger_edge expected_rising =
-      hal::interrupt_pin::trigger_edge::rising;
-    const hal::interrupt_pin::trigger_edge expected_both =
-      hal::interrupt_pin::trigger_edge::both;
-    hal::mock::interrupt_pin mock;
+    callback1(false);
+    expect(that % 1 == counter);
 
-    // Exercise
-    auto result1 = mock.attach_interrupt(expected_callback, expected_falling);
-    auto result2 = mock.attach_interrupt(expected_callback, expected_rising);
-    auto result3 = mock.attach_interrupt(expected_callback, expected_both);
+    callback2(false);
+    expect(that % 2 == counter);
 
-    // Verify
-    expect(bool{ result1 });
-    expect(bool{ result2 });
-    expect(bool{ result3 });
-    expect(expected_falling ==
-           std::get<1>(mock.spy_attach_interrupt.call_history().at(0)));
-    expect(expected_rising ==
-           std::get<1>(mock.spy_attach_interrupt.call_history().at(1)));
-    expect(expected_both ==
-           std::get<1>(mock.spy_attach_interrupt.call_history().at(2)));
+    callback3(false);
+    expect(that % 3 == counter);
   };
   "hal::mock::interrupt_pin::reset()"_test = []() {
     // Setup
     constexpr hal::interrupt_pin::settings mock_settings_default{};
-    const std::function<void(void)> expected_callback = []() {};
-    const hal::interrupt_pin::trigger_edge expected_trigger =
-      hal::interrupt_pin::trigger_edge::falling;
+    const std::function<void(bool)> expected_callback = [](bool) {};
     hal::mock::interrupt_pin mock;
     (void)mock.configure(mock_settings_default);
     expect(that % 1 == mock.spy_configure.call_history().size());
-    (void)mock.attach_interrupt(expected_callback, expected_trigger);
-    expect(that % 1 == mock.spy_attach_interrupt.call_history().size());
-    (void)mock.detach_interrupt();
-    expect(that % 1 == mock.spy_detach_interrupt.call_history().size());
+    (void)mock.on_trigger(expected_callback);
+    expect(that % 1 == mock.spy_on_trigger.call_history().size());
 
     // Exercise
     mock.reset();
 
     // Verify
     expect(that % 0 == mock.spy_configure.call_history().size());
-    expect(that % 0 == mock.spy_attach_interrupt.call_history().size());
-    expect(that % 0 == mock.spy_detach_interrupt.call_history().size());
+    expect(that % 0 == mock.spy_on_trigger.call_history().size());
   };
 };
 }  // namespace hal

--- a/tests/output_pin/mock.test.cpp
+++ b/tests/output_pin/mock.test.cpp
@@ -11,7 +11,6 @@ boost::ut::suite output_pin_mock_test = []() {
     constexpr hal::output_pin::settings mock_settings_custom{
       .resistor = pin_resistor::pull_down,
       .open_drain = true,
-      .starting_level = false,
     };
     hal::mock::output_pin mock;
 


### PR DESCRIPTION
- Remove extraneous includes in headers
- Replace hertz frequency with std::uint32_t for settings objects as
  dealing with an integer in terms of comparisons is easier and no
  peripheral driver is expected to need to support frequencies beyond
  4.2 GHz
- Rename "attach_interrupt" functions to "on_<event>" to have a more
  understandable API name (can, interrupt_pin)
- Remove "detach_interrupt" and similar APIs as the "on_<event>" API
  can do the same work by defining that "nullptr" callbacks are signals
  to disable the interrupt. (can, interrupt_pin)
- General fix-up of documentation throughout interfaces
- Move trigger_edge from interrupt_pin::on_trigger to settings object as
  it is unlikely that a driver will need to change the trigger level
  multiple times.
- Remove starting level from output_pin's settings object as it is an
  impossible requirement once an output pin's object has been created
- Remove interrupt_pin::read() function for reading the pin's current
  state and instead add the pin state to the handler's function
  signature.

Issue https://github.com/libhal/libhal/issues/293