### PR TITLE
Interface Review Changes 2

### DIFF
--- a/include/libhal/can/interface.hpp
+++ b/include/libhal/can/interface.hpp
@@ -24,7 +24,7 @@ public:
   struct settings
   {
     /// Bus clock rate in hertz
-    std::uint32_t clock_rate{};
+    hertz clock_rate{};
 
     /**
      * @brief Default operators for <, <=, >, >= and ==

--- a/include/libhal/output_pin/interface.hpp
+++ b/include/libhal/output_pin/interface.hpp
@@ -27,7 +27,7 @@ public:
   {
     /// Pull resistor for the pin. This generally only helpful when open
     /// drain is enabled.
-    pin_resistor resistor = pin_resistor::pull_up;
+    pin_resistor resistor = pin_resistor::none;
 
     /// Starting level of the output pin. HIGH voltage defined as true and LOW
     /// voltage defined as false.

--- a/include/libhal/serial/interface.hpp
+++ b/include/libhal/serial/interface.hpp
@@ -116,14 +116,12 @@ public:
   }
 
   /**
-   * @brief Write data on the transmitter line of the port
-   *
-   * This function will block until the entire transfer is finished.
+   * @brief Write data to the transmitter line of the serial port
    *
    * @param p_data - data to be transmitted over the serial port
-   * @return status - success or failure
+   * @return result<size_t> - the number of bytes transmitted
    */
-  [[nodiscard]] status write(std::span<const hal::byte> p_data) noexcept
+  [[nodiscard]] result<size_t> write(std::span<const hal::byte> p_data) noexcept
   {
     return driver_write(p_data);
   }
@@ -191,7 +189,8 @@ public:
 
 private:
   virtual status driver_configure(const settings& p_settings) noexcept = 0;
-  virtual status driver_write(std::span<const hal::byte> p_data) noexcept = 0;
+  virtual result<size_t> driver_write(
+    std::span<const hal::byte> p_data) noexcept = 0;
   virtual bytes_available_t driver_bytes_available() noexcept = 0;
   virtual result<std::span<hal::byte>> driver_read(
     std::span<hal::byte> p_data) noexcept = 0;

--- a/include/libhal/serial/util.hpp
+++ b/include/libhal/serial/util.hpp
@@ -19,10 +19,10 @@ namespace hal {
  *
  * @param p_serial - the serial port that will be written to
  * @param p_data_out - the data to be written out the port
- * @return status - success or failure
+ * @return result<size_t> - success or failure
  * serial::write returns an error from the serial port.
  */
-[[nodiscard]] inline status write(
+[[nodiscard]] inline result<size_t> write(
   serial& p_serial,
   std::span<const hal::byte> p_data_out) noexcept
 {

--- a/tests/serial/util.test.cpp
+++ b/tests/serial/util.test.cpp
@@ -19,14 +19,14 @@ boost::ut::suite serial_util_test = []() {
     {
       return {};
     }
-    [[nodiscard]] status driver_write(
+    [[nodiscard]] result<size_t> driver_write(
       std::span<const hal::byte> p_data) noexcept override
     {
       if (p_data[0] == write_failure_byte) {
         return hal::new_error();
       }
       m_out = p_data;
-      return {};
+      return p_data.size();
     }
 
     [[nodiscard]] bytes_available_t driver_bytes_available() noexcept override
@@ -74,6 +74,7 @@ boost::ut::suite serial_util_test = []() {
 
       // Verify
       expect(bool{ result });
+      expect(result.value() == expected_payload.size());
       expect(!serial.flush_called);
       expect(that % expected_payload.data() == serial.m_out.data());
       expect(that % expected_payload.size() == serial.m_out.size());


### PR DESCRIPTION
- output_pin pin resistor now defaults to none
- can::settings::clock_rate is now type hertz
- serial::write now returns result<size_t> to inform the caller of the
  number of bytes that has been transmitted
- write(serial&) now returns result<size_t> as well

Resolves #411
Resolves #410