### PR TITLE
Make conanfile.py similiar to libhal file on CCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ ncc.stderr
 
 # OS files
 .DS_Store
+
+# Conan Files
+graph_info.json
+conaninfo.txt
+conan.lock
+conanbuildinfo.txt

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,22 +1,69 @@
-from conans import ConanFile
+import os
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.layout import basic_layout
+from conan.tools.files import copy
+from conan import ConanFile
+
+required_conan_version = ">=1.50.0"
 
 
-class libhal_conan(ConanFile):
+class LibHALConan(ConanFile):
     name = "libhal"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"
     description = ("A collection of interfaces and abstractions for embedded "
                    "peripherals and devices using modern C++")
-    topics = ("peripherals", "hardware", "abstraction", "devices")
+    topics = ("peripherals", "hardware", "abstraction", "devices", "hal")
     settings = "os", "compiler", "arch", "build_type"
     exports_sources = "include/*"
     no_copy_source = True
 
-    def package(self):
-        self.copy("*LICENSE*", dst="licenses", keep_path=False)
-        self.copy("*.h")
-        self.copy("*.hpp")
-
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
+
+    @property
+    def _min_cppstd(self):
+        return "20"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "11",
+            "Visual Studio": "17",
+            "msvc": "19.22",
+            "clang": "13",
+            "apple-clang": "13.1.6"
+        }
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+        def lazy_lt_semver(v1, v2):
+            lv1 = [int(v) for v in v1.split(".")]
+            lv2 = [int(v) for v in v2.split(".")]
+            min_length = min(len(lv1), len(lv2))
+            return lv1[:min_length] < lv2[:min_length]
+        compiler = str(self.settings.compiler)
+        version = str(self.settings.compiler.version)
+        minimum_version = self._compilers_minimum_version.get(compiler, False)
+        if not minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.name} requires C++20. Your compiler configuration ({compiler}-{version}) wasn't validated. \
+                please report an issue if it does actually supports c++20.")
+        elif lazy_lt_semver(version, minimum_version):
+            raise ConanInvalidConfiguration(
+                f"{self.name} {self.version} requires C++20, which your compiler ({compiler}-{version}) does not support")
+
+    def layout(self):
+        basic_layout(self)
+
+    def package(self):
+        copy(self, "LICENSE", dst=os.path.join(
+            self.package_folder, "licenses"),  src=self.source_folder)
+        copy(self, "*.h", dst=os.path.join(self.package_folder, "include"),
+             src=os.path.join(self.source_folder, "include"))
+        copy(self, "*.hpp", dst=os.path.join(self.package_folder,
+             "include"), src=os.path.join(self.source_folder, "include"))

--- a/cspell.json
+++ b/cspell.json
@@ -53,7 +53,9 @@
         "UART",
         "ctest",
         "psabi",
-        "conans"
+        "conans",
+        "bindirs",
+        "conanrun"
     ],
     "ignorePaths": [
         "**/third_party/leaf.hpp",

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,20 +1,9 @@
-cmake_minimum_required(VERSION 3.1.2)
+cmake_minimum_required(VERSION 3.1.)
+project(test_package LANGUAGES CXX)
 
-set(CMAKE_C_COMPILER "gcc-11")
-set(CMAKE_CXX_COMPILER "g++-11")
-
-project(test_package VERSION 0.0.1 LANGUAGES CXX)
-
-include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
-
-find_package(libhal REQUIRED)
+find_package(libhal REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} main.cpp)
-
-target_include_directories(${PROJECT_NAME} PUBLIC .)
-target_compile_options(${PROJECT_NAME} PRIVATE
-  -Werror -Wall -Wextra -Wno-psabi -Wno-unused-function -Wconversion)
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(${PROJECT_NAME} PRIVATE libhal::libhal)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,9 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conan.tools.cmake import CMake, cmake_layout
+import os
 
 
-class LibhalTestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = ("cmake_find_package", "cmake_paths")
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -11,5 +20,6 @@ class LibhalTestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            self.run("./test_package")
+        if not cross_building(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/test_package/libhal.tweaks.hpp
+++ b/test_package/libhal.tweaks.hpp
@@ -1,9 +1,0 @@
-#pragma once
-
-namespace hal::config {
-inline int callback_call_count = 0;
-constexpr bool on_error_callback_enabled = true;
-constexpr auto on_error_callback = []() { callback_call_count++; };
-// TODO(#404): Change this to "float" when the platform can support it
-using float_type = double;
-}  // namespace hal::config


### PR DESCRIPTION
- CCI = conan center index
- Add C++20 & compiler version requirements
- CCI and local conanfile.py difference is "export_sources" since CCI
  uses a conandata.yml file to download an archive file where as the
  repo version must pull the resources from our local directory.
- Simplify test_package CMakeLists.txt, removing all GCC specific
  warning flags and the like.
- Remove test_package tweaks file as the defaults will suffice.
- Add conanfiles to gitignore

Resolves #405