### PR TITLE
Make frequency related variables type `hertz`

### DIFF
--- a/include/libhal/can/interface.hpp
+++ b/include/libhal/can/interface.hpp
@@ -24,7 +24,7 @@ public:
   struct settings
   {
     /// Bus clock rate in hertz
-    hertz clock_rate{};
+    hertz clock_rate = 100.0_kHz;
 
     /**
      * @brief Default operators for <, <=, >, >= and ==
@@ -33,6 +33,17 @@ public:
      */
     [[nodiscard]] constexpr auto operator<=>(const settings&) const noexcept =
       default;
+
+    /**
+     * @brief Operators ==
+     *
+     * @return auto - result of the comparison
+     */
+    [[nodiscard]] constexpr auto operator==(
+      const settings& p_settings) const noexcept
+    {
+      return equals(clock_rate, p_settings.clock_rate);
+    }
   };
 
   /// Can message ID type trait

--- a/include/libhal/i2c/interface.hpp
+++ b/include/libhal/i2c/interface.hpp
@@ -46,6 +46,17 @@ public:
      */
     [[nodiscard]] constexpr auto operator<=>(const settings&) const noexcept =
       default;
+
+    /**
+     * @brief Operators ==
+     *
+     * @return auto - result of the comparison
+     */
+    [[nodiscard]] constexpr auto operator==(
+      const settings& p_settings) const noexcept
+    {
+      return equals(clock_rate, p_settings.clock_rate);
+    }
   };
 
   /**

--- a/include/libhal/serial/interface.hpp
+++ b/include/libhal/serial/interface.hpp
@@ -68,7 +68,7 @@ public:
     };
 
     /// The operating speed of the baud rate (in units of bits per second)
-    uint32_t baud_rate = 115200;
+    hertz baud_rate = 115200.0f;
     /// Number of stop bits for each frame
     stop_bits stop = stop_bits::one;
     /// Parity bit type for each frame
@@ -81,6 +81,18 @@ public:
      */
     [[nodiscard]] constexpr auto operator<=>(const settings&) const noexcept =
       default;
+
+    /**
+     * @brief Operators ==
+     *
+     * @return auto - result of the comparison
+     */
+    [[nodiscard]] constexpr auto operator==(
+      const settings& p_settings) const noexcept
+    {
+      return stop == p_settings.stop && parity == p_settings.parity &&
+             equals(baud_rate, p_settings.baud_rate);
+    }
   };
 
   /// Structure informing the caller of the number of bytes that can be read out

--- a/include/libhal/spi/interface.hpp
+++ b/include/libhal/spi/interface.hpp
@@ -25,19 +25,33 @@ public:
   struct settings
   {
     /// Serial clock frequency in hertz
-    std::uint32_t clock_rate = 100'000;
+    hertz clock_rate = 100.0_kHz;
     /// The polarity of the pins when the signal is idle
     bool clock_idles_high = false;
     /// The phase of the clock signal when communicating
     bool data_valid_on_trailing_edge = false;
 
     /**
-     * @brief Default operators for <, <=, >, >= and ==
+     * @brief Default operators for <, <=, >, >=
      *
      * @return auto - result of the comparison
      */
     [[nodiscard]] constexpr auto operator<=>(const settings&) const noexcept =
       default;
+
+    /**
+     * @brief Operators ==
+     *
+     * @return auto - result of the comparison
+     */
+    [[nodiscard]] constexpr auto operator==(
+      const settings& p_settings) const noexcept
+    {
+      return clock_idles_high == p_settings.clock_idles_high &&
+             data_valid_on_trailing_edge ==
+               p_settings.data_valid_on_trailing_edge &&
+             equals(clock_rate, p_settings.clock_rate);
+    }
   };
 
   /// Default filler data placed on the bus in place of actual write data when


### PR DESCRIPTION
- Add `operator==` to each settings object with a float member
- Define default for hal::can::settings::clock_rate

Resolves #374