### PR TITLE
hal::serial combine read + bytes_available

### DIFF
--- a/include/libhal/serial/util.hpp
+++ b/include/libhal/serial/util.hpp
@@ -22,7 +22,7 @@ namespace hal {
  * @return result<size_t> - success or failure
  * serial::write returns an error from the serial port.
  */
-[[nodiscard]] inline result<size_t> write_partial(
+[[nodiscard]] inline result<serial::write_t> write_partial(
   serial& p_serial,
   std::span<const hal::byte> p_data_out) noexcept
 {
@@ -46,11 +46,10 @@ namespace hal {
   std::span<hal::byte> p_data_in,
   timeout auto p_timeout) noexcept
 {
-  std::span<hal::byte> data_in = p_data_in;
+  auto read_result = HAL_CHECK(p_serial.read(p_data_in));
 
-  while (data_in.size() > 0) {
-    auto read_bytes = HAL_CHECK(p_serial.read(data_in));
-    data_in = data_in.subspan(read_bytes.size());
+  while (read_result.remaining.size() != 0) {
+    read_result = HAL_CHECK(p_serial.read(read_result.remaining));
     HAL_CHECK(p_timeout());
   }
 

--- a/include/libhal/steady_clock/timeout.hpp
+++ b/include/libhal/steady_clock/timeout.hpp
@@ -33,13 +33,14 @@ public:
     const auto frequency = p_steady_clock.frequency();
     const auto tick_period = wavelength<period>(frequency);
     auto ticks_required = p_duration / tick_period;
+    using unsigned_ticks = std::make_unsigned_t<decltype(ticks_required)>;
 
     if (ticks_required <= 1) {
       ticks_required = 1;
     }
 
-    const auto future_timestamp =
-      ticks_required + HAL_CHECK(p_steady_clock.uptime());
+    const auto ticks = static_cast<unsigned_ticks>(ticks_required);
+    const auto future_timestamp = ticks + HAL_CHECK(p_steady_clock.uptime());
 
     return steady_clock_timeout(p_steady_clock, future_timestamp);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1...3.21)
+cmake_minimum_required(VERSION 3.12)
 
 set(CMAKE_C_COMPILER "gcc-11")
 set(CMAKE_CXX_COMPILER "g++-11")

--- a/tests/error.test.cpp
+++ b/tests/error.test.cpp
@@ -47,7 +47,7 @@ boost::ut::suite error_test = []() {
 
     attempt_all(
       [expected]() -> status { return new_error(); },
-      [&value_to_be_change](int) {},
+      [](int) {},
       [&value_to_be_change, expected]() { value_to_be_change = expected; });
 
     // Verify

--- a/tests/ostreams.hpp
+++ b/tests/ostreams.hpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <iomanip>
+#include <iostream>
 #include <span>
 
 #include <libhal/percentage.hpp>
@@ -14,6 +15,26 @@ inline std::ostream& operator<<(
 {
   return (os << p_duration.count() << " * (" << Period::num << "/"
              << Period::den << ")s");
+}
+
+template<typename T, size_t size>
+inline std::ostream& operator<<(std::ostream& os,
+                                const std::array<T, size>& p_array)
+{
+  os << "{";
+  for (const auto& element : p_array) {
+    os << element << ", ";
+  }
+  return os << "}\n";
+}
+template<typename T>
+inline std::ostream& operator<<(std::ostream& os, const std::span<T>& p_array)
+{
+  os << "{";
+  for (const auto& element : p_array) {
+    os << element << ", ";
+  }
+  return os << "}\n";
 }
 
 template<typename T, size_t size>


### PR DESCRIPTION
Rather than make these two seperate calls, in general the information
about the number of bytes remaining and the capacity is useful after
each read operation. This is due to the idea it is unlikely that a
user will ever run bytes_available and not also then run read. In
general drivers that read from serial simply want to read whats
available from the serial working buffer.

write now returns a "write_t" which only includes a size_t variable for
now. This will allow for further expansion in the future if it is deemed
necessary.

Issues #293