### PR TITLE
hal::timer update API specifications

### DIFF
--- a/include/libhal/timer/mock.hpp
+++ b/include/libhal/timer/mock.hpp
@@ -22,7 +22,7 @@ struct timer : public hal::timer
   void reset()
   {
     spy_schedule.reset();
-    spy_clear.reset();
+    spy_cancel.reset();
     spy_is_running.reset();
   }
 
@@ -31,7 +31,7 @@ struct timer : public hal::timer
   /// Spy handler for hal::timer::is_running()
   spy_handler<bool> spy_is_running;
   /// Spy handler for hal::timer::clear()
-  spy_handler<bool> spy_clear;
+  spy_handler<bool> spy_cancel;
 
 private:
   status driver_schedule(std::function<void(void)> p_callback,
@@ -48,10 +48,10 @@ private:
     }
     return m_is_running;
   }
-  status driver_clear() noexcept override
+  status driver_cancel() noexcept override
   {
     m_is_running = false;
-    return spy_clear.record(true);
+    return spy_cancel.record(true);
   }
   bool m_is_running = false;
 };

--- a/tests/timer/mock.test.cpp
+++ b/tests/timer/mock.test.cpp
@@ -18,7 +18,7 @@ boost::ut::suite timer_mock_test = []() {
   expect(expected_delay == std::get<1>(mock.spy_schedule.call_history().at(0)));
   expect(true == mock.is_running().value());
   expect(true == std::get<0>(mock.spy_is_running.call_history().at(1)));
-  expect(bool{ mock.clear() });
-  expect(true == std::get<0>(mock.spy_clear.call_history().at(0)));
+  expect(bool{ mock.cancel() });
+  expect(true == std::get<0>(mock.spy_cancel.call_history().at(0)));
 };
 }  // namespace hal


### PR DESCRIPTION
- hal::timer::clear -> hal::timer::cancel as the name makes more sense
  semantically
- Remove "invalid" from out_of_bounds as the information should be known
  by the caller
- Specify that tick periods must be integer multiples of 1 nanosecond
- Specify that scheduled time periods are rounded down
- Specify that scheduled time periods that result in 0 ticks will be
  scheduled to be executed after a single tick.

Issues #293