### PR TITLE
Remove cron jobs from docs & lint

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 12 * * 0'
 
 jobs:
   docs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 12 * * 0'
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,9 @@ jobs:
       - name: 📥 Install conan
         run: pip install conan
 
+      - name: 📥 Install gcovr
+        run: pip install --upgrade gcovr
+
       - name: 📡 Add `libhal-trunk` conan remote
         run: |
              conan remote add libhal-trunk \


### PR DESCRIPTION
There is no reason to run a cron job for docs and lint for code that has not changed.