### PR TITLE
Add hal::as_bytes() hal::as_writable_bytes

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -61,7 +61,7 @@ class LibHALConan(ConanFile):
         basic_layout(self)
 
     def requirements(self):
-        self.requires("boost-leaf/0.4.0@")
+        self.requires("boost-leaf/[x, include_prerelease=True]@")
 
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(

--- a/include/libhal/as_bytes.hpp
+++ b/include/libhal/as_bytes.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <span>
+
+#include "units.hpp"
+
+namespace hal {
+template<typename T>
+constexpr std::span<hal::byte> as_writable_bytes(T* p_address,
+                                                 size_t p_number_of_elements)
+{
+  auto* start = reinterpret_cast<hal::byte*>(p_address);
+  size_t number_of_bytes = sizeof(T) * p_number_of_elements;
+  return std::span<hal::byte>(start, number_of_bytes);
+}
+
+template<typename T>
+constexpr std::span<const hal::byte> as_bytes(const T* p_address,
+                                              size_t p_number_of_elements)
+{
+  auto* start = reinterpret_cast<const hal::byte*>(p_address);
+  size_t number_of_bytes = sizeof(T) * p_number_of_elements;
+  return std::span<const hal::byte>(start, number_of_bytes);
+}
+
+template<typename T>
+concept convertible_to_bytes = requires(T a)
+{
+  *a.data();
+  a.size();
+};
+
+constexpr std::span<hal::byte> as_writable_bytes(
+  convertible_to_bytes auto& p_container)
+{
+  return as_writable_bytes(p_container.data(), p_container.size());
+}
+
+constexpr std::span<const hal::byte> as_bytes(
+  const convertible_to_bytes auto& p_container)
+{
+  return as_bytes(p_container.data(), p_container.size());
+}
+
+template<typename T, std::size_t N>
+constexpr std::span<const hal::byte> as_bytes(const T (&array)[N])
+{
+  return as_bytes(array, N);
+}
+}  // namespace hal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(${TEST_NAME}
   servo/rc.test.cpp
   i2c/minimum_speed.test.cpp
 
+  as_bytes.test.cpp
   static_memory_resource.test.cpp
   enum.test.cpp
   timeout.test.cpp

--- a/tests/as_bytes.test.cpp
+++ b/tests/as_bytes.test.cpp
@@ -1,0 +1,143 @@
+#include <boost/ut.hpp>
+#include <libhal/as_bytes.hpp>
+
+#include <span>
+#include <vector>
+
+namespace hal {
+boost::ut::suite as_bytes_test = []() {
+  using namespace boost::ut;
+
+  "hal::as_bytes()"_test = []() {
+    "Zero"_test = []() {
+      // Setup
+      std::span<const hal::byte> expected_const{};
+      std::span<hal::byte> expected_writable{};
+      std::vector<float> empty_vector;
+
+      {
+        // Exercise
+        auto actual = hal::as_bytes(std::span<int>{});
+        // Verify
+        expect(that % expected_const.data() == actual.data());
+        expect(that % expected_const.size() == actual.size());
+      }
+      {
+        // Exercise
+        auto actual = hal::as_bytes(empty_vector);
+        // Verify
+        expect(that % expected_const.data() == actual.data());
+        expect(that % expected_const.size() == actual.size());
+      }
+      {
+        // Exercise
+        auto actual = hal::as_writable_bytes(expected_writable);
+        // Verify
+        expect(that % expected_writable.data() == actual.data());
+        expect(that % expected_writable.size() == actual.size());
+      }
+    };
+
+    "One"_test = []() {
+      // Setup
+      std::array<std::int32_t, 1> array{ 1234 };
+      std::vector<std::int32_t> vector;
+      vector.push_back(1);
+
+      auto* array_pointer = reinterpret_cast<const hal::byte*>(array.data());
+      auto* vector_pointer = reinterpret_cast<const hal::byte*>(vector.data());
+
+      auto vector_byte_size =
+        sizeof(decltype(vector)::value_type) * vector.size();
+      auto array_byte_size = sizeof(decltype(array)::value_type) * array.size();
+
+      {
+        // Exercise
+        auto actual = hal::as_bytes(array);
+        // Verify
+        expect(that % array_pointer == actual.data());
+        expect(that % array_byte_size == actual.size());
+      }
+      {
+        // Exercise
+        auto actual = hal::as_bytes(vector);
+        // Verify
+        expect(that % vector_pointer == actual.data());
+        expect(that % vector_byte_size == actual.size());
+      }
+      {
+        // Exercise
+        auto actual = hal::as_writable_bytes(array);
+        // Verify
+        expect(that % array_pointer == actual.data());
+        expect(that % array_byte_size == actual.size());
+      }
+    };
+
+    "Standard Usage"_test = []() {
+      // Setup
+      std::array<std::int32_t, 17> array{ 1234 };
+      std::vector<std::int32_t> vector;
+      vector.push_back(1);
+      vector.push_back(2);
+      vector.push_back(3);
+      vector.push_back(4);
+      vector.push_back(10293);
+
+      auto* array_pointer = reinterpret_cast<const hal::byte*>(array.data());
+      auto* vector_pointer = reinterpret_cast<const hal::byte*>(vector.data());
+
+      constexpr auto array_element_size = sizeof(decltype(array)::value_type);
+      constexpr auto array_byte_size = array_element_size * array.size();
+
+      constexpr auto vector_element_size = sizeof(decltype(vector)::value_type);
+      const auto vector_byte_size = vector_element_size * vector.size();
+
+      {
+        // Exercise
+        auto actual = hal::as_bytes(array);
+        // Verify
+        expect(that % array_pointer == actual.data());
+        expect(that % array_byte_size == actual.size());
+      }
+      {
+        // Exercise
+        auto actual = hal::as_bytes(vector);
+        // Verify
+        expect(that % vector_pointer == actual.data());
+        expect(that % vector_byte_size == actual.size());
+      }
+      {
+        // Exercise
+        auto actual = hal::as_writable_bytes(array);
+        // Verify
+        expect(that % array_pointer == actual.data());
+        expect(that % array_byte_size == actual.size());
+      }
+      {
+        // Exercise
+        auto actual = hal::as_bytes("Hello World");
+        // Verify
+        // Verify: this works because almost all compilers will find common
+        // strings and place them in the same location, therefor, the location
+        // of a string "Hello World" will always be the same.
+        expect(that % reinterpret_cast<const hal::byte*>("Hello World") ==
+               actual.data());
+        expect(that % sizeof("Hello World") == actual.size());
+      }
+      {
+        int c_int_array[] = { 1, 2, 3, 5 };
+        // Exercise
+        auto actual = hal::as_bytes(c_int_array);
+        // Verify
+        // Verify: this works because almost all compilers will find common
+        // strings and place them in the same location, therefor, the location
+        // of a string "Hello World" will always be the same.
+        expect(that % reinterpret_cast<const hal::byte*>(c_int_array) ==
+               actual.data());
+        expect(that % sizeof(c_int_array) == actual.size());
+      }
+    };
+  };
+};
+}

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 boost-ext-ut/1.1.8
-boost-leaf/0.4.0
+boost-leaf/[x, include_prerelease=True]
 
 [generators]
 CMakeToolchain


### PR DESCRIPTION
`hal::as_bytes()` converts any container, C-style array or pointer and
size set to a span of bytes. This is similiar to std::as_bytes() except
that function only works on spans to be begin with. This works with any
structure with a `data()` and `size()` class function as well as C-style
arrays.

Bump boost-leaf version to work with latest on remote.

Resolves https://github.com/libhal/libhal/issues/452