### PR TITLE
[deploy] Force test_package verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         run: conan user -p $API_KEY -r libhal-trunk $JFROG_USER
 
       - name: 📦 Create Conan Package & Verify Test Package
-        run: conan create .
+        run: conan create . --test-folder test_package
 
       - name: 🆙 Upload package to `libhal-trunk` repo
         if: ${{ inputs.library == '' }}


### PR DESCRIPTION
Update deploy.yml require that a test_package exist when performing conan create by specifying a test package directory which prevents conan create from skipping that step