### PR TITLE
Deploy check occurs on PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
       library:
         required: true
         type: string
+  pull_request:
   push:
     branches:
       - main
@@ -47,11 +48,11 @@ jobs:
         run: conan create . --test-folder test_package
 
       - name: 🆙 Upload package to `libhal-trunk` repo
-        if: ${{ inputs.library == '' }}
+        if: ${{ inputs.library == '' && github.ref == 'refs/heads/main'}}
         run: conan upload "libhal/*" --confirm --all -r=libhal-trunk
 
       - name: 🆙 Upload package to `libhal-trunk` repo
-        if: ${{ inputs.library != '' }}
+        if: ${{ inputs.library != '' && github.ref == 'refs/heads/main'}}
         run: |
              conan upload "${{ inputs.library }}/*" --confirm --all \
              -r=libhal-trunk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,8 +43,5 @@ jobs:
       - name: 📡 Enable conan revision mode
         run: conan config set general.revisions_enabled=True
 
-      - name: 📦 Create Conan Package & Verify Test Package
-        run: conan create .
-
       - name: 🔬 Build & Run Unit Tests
         run: ./tests/run.sh


### PR DESCRIPTION
- Remove conan package creation from tests.yml as that is handled by the deploy.yml
- Add deploy.yml check to PRs
- deploy.yml check will NOT attempt to deploy on PRs and will only deploy if the branch name is "main"