### PR TITLE
Remove boost::ut::throws calls w/ Boost.LEAF

### DIFF
--- a/tests/input_pin/mock.test.cpp
+++ b/tests/input_pin/mock.test.cpp
@@ -7,7 +7,7 @@ namespace hal {
 boost::ut::suite input_pin_mock_test = []() {
   using namespace boost::ut;
 
-  "hal::mock::inputput_pin::configure()"_test = []() {
+  "hal::mock::input_pin::configure()"_test = []() {
     // Setup
     constexpr hal::input_pin::settings mock_settings_default{};
     constexpr hal::input_pin::settings mock_settings_custom{
@@ -40,7 +40,7 @@ boost::ut::suite input_pin_mock_test = []() {
     expect(that % true == mock.level().value());
     expect(that % false == mock.level().value());
     expect(that % true == mock.level().value());
-    expect(throws([&mock] { mock.level().value(); }));
+    expect(!bool{ mock.level() });
   };
   "hal::mock::input_pin::reset()"_test = []() {
     // Setup

--- a/tests/math.test.cpp
+++ b/tests/math.test.cpp
@@ -14,14 +14,10 @@ boost::ut::suite math_test = []() {
       expect(that % 2147483648L == multiply(-1L, -2147483648L).value());
     };
     "Exceptions"_test = []() {
-      expect(throws([] {
-        return multiply(std::uint32_t{ 5U }, std::uint32_t{ 4294967295U })
-          .value();
-      }));
-      expect(throws([] {
-        return multiply(std::uint32_t{ 4L }, std::uint32_t{ 1073741824L })
-          .value();
-      }));
+      expect(
+        !bool{ multiply(std::uint32_t{ 5U }, std::uint32_t{ 4294967295U }) });
+      expect(
+        !bool{ multiply(std::uint32_t{ 4L }, std::uint32_t{ 1073741824L }) });
     };
     "Standard Usage"_test = []() {
       expect(that % 75 == multiply(15, 5).value());

--- a/tests/steady_clock/mock.test.cpp
+++ b/tests/steady_clock/mock.test.cpp
@@ -29,6 +29,6 @@ boost::ut::suite steady_clock_mock_test = []() {
   expect(that % expected1 == result1);
   expect(that % expected2 == result2);
   expect(that % expected3 == result3);
-  expect(throws([&mock] { mock.uptime().value(); }));
+  expect(!bool{ mock.uptime() });
 };
 }  // namespace hal


### PR DESCRIPTION
A call to boost::leaf::result::value() when there is no value executes an assert and this will abort the program at that location rather than throwing. The behavior doesn't seem to be consistent across platforms, but on M1 mac systems, it aborts in the middle of the unit test runtime execution.

Removing this will make unit tests workable on M1 machines and more consistent everywhere else.