### PR TITLE
Add hal::write(serial&) variants

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.3"
+    version = "0.1.4"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"


### PR DESCRIPTION
Add helper functions for writing data over a serial port such as a const char span or a string_view.

Resolves #412