### PR TITLE
Remove write(serial, std::span<const char>)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.4"
+    version = "0.1.5"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/serial/util.hpp
+++ b/include/libhal/serial/util.hpp
@@ -58,19 +58,6 @@ namespace hal {
  * @return status - success or failure
  */
 [[nodiscard]] inline status write(serial& p_serial,
-                                  std::span<const char> p_data_out) noexcept
-{
-  return write(p_serial, hal::as_bytes(p_data_out));
-}
-
-/**
- * @brief Write std::span of const char to a serial port
- *
- * @param p_serial - the serial port that will be written to
- * @param p_data_out - chars to be written out the port
- * @return status - success or failure
- */
-[[nodiscard]] inline status write(serial& p_serial,
                                   std::string_view p_data_out) noexcept
 {
   return write(p_serial, hal::as_bytes(p_data_out));

--- a/tests/serial/util.test.cpp
+++ b/tests/serial/util.test.cpp
@@ -147,24 +147,6 @@ boost::ut::suite serial_util_test = []() {
       expect(that % !serial.read_was_called);
     };
 
-    "[success] write(std::span<const char>)"_test = []() {
-      // Setup
-      fake_serial serial;
-      const std::array<char, 4> expected_payload{ 'a', 'b', 'c', 'd' };
-      serial.single_byte_out = true;
-
-      // Exercise
-      auto result = write(serial, expected_payload);
-
-      // Verify
-      expect(bool{ result });
-      expect(!serial.flush_called);
-      expect(that % expected_payload.end()[-1] == serial.m_out[0]);
-      expect(that % 1 == serial.m_out.size());
-      expect(that % expected_payload.size() == serial.write_call_count);
-      expect(that % !serial.read_was_called);
-    };
-
     "[success] write(std::string_view)"_test = []() {
       // Setup
       fake_serial serial;


### PR DESCRIPTION
Overload resolution is ambiguous with string literals and because of this, std::string_view was kept as it made more semantic sense.

hal::as_bytes() can be used on containers to pass them to write()