### PR TITLE
Migrate can_router to static_list

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.12"
+    version = "0.1.13"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/can/interface.hpp
+++ b/include/libhal/can/interface.hpp
@@ -22,6 +22,9 @@ namespace hal {
 class can
 {
 public:
+  /// Can message ID type trait
+  using id_t = uint32_t;
+
   /// Generic settings for a can peripheral
   ///
   /// CAN Bit Quanta Timing Diagram of:
@@ -162,9 +165,6 @@ public:
     }
   };
 
-  /// Can message ID type trait
-  using id_t = uint32_t;
-
   /// Structure of a CAN message
   struct message_t
   {
@@ -177,6 +177,14 @@ public:
     /// Whether or not the message is a remote request frame. If true, then
     /// length and payload are ignored.
     bool is_remote_request = false;
+
+    /**
+     * @brief Default operators for <, <=, >, >= and ==
+     *
+     * @return auto - result of the comparison
+     */
+    [[nodiscard]] constexpr auto operator<=>(const message_t&) const noexcept =
+      default;
   };
 
   // Receive handler for can messages

--- a/include/libhal/can/router.hpp
+++ b/include/libhal/can/router.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <cstdint>
-#include <memory_resource>
-#include <unordered_map>
-
+#include "../move_interceptor.hpp"
+#include "../static_callable.hpp"
+#include "../static_list.hpp"
 #include "interface.hpp"
 
 namespace hal {
@@ -15,81 +14,42 @@ namespace hal {
  * @brief Route CAN messages received on the can bus to callbacks based on ID.
  *
  */
-class can_router
+class can_router : public move_interceptor<can_router>
 {
 public:
-  using handler = std::function<hal::can::handler>;
-  using route_map = std::pmr::unordered_map<hal::can::id_t, handler>;
-  using iterator = route_map::iterator;
+  friend class move_interceptor<can_router>;
 
-  /**
-   * @brief Construct a new can message router
-   *
-   * @param p_can - can peripheral to route messages for
-   * @param p_memory_resource - memory resource used for storing callbacks
-   */
-  can_router(hal::can& p_can,
-             std::pmr::memory_resource& p_memory_resource) noexcept
-    : m_can(&p_can)
-    , m_messages(&p_memory_resource)
+  static constexpr auto noop =
+    []([[maybe_unused]] const can::message_t& p_message) {};
+
+  using message_handler = std::function<hal::can::handler>;
+
+  struct route
   {
+    hal::can::id_t id = 0;
+    message_handler handler = noop;
+  };
+
+  using route_item = hal::static_list<route>::item;
+
+  static result<can_router> create(hal::can& p_can)
+  {
+    can_router new_can_router(p_can);
+    HAL_CHECK(p_can.on_receive(std::ref(new_can_router)));
+    return new_can_router;
   }
 
-  /**
-   * @brief Add an empty receive callback to the routing map
-   *
-   *
-   * @param p_id - Associated ID of messages to be stored.
-   * @return status - error or success
-   * @throws std::errc::not_enough_memory if the internal network map does not
-   * have enough space to add another handler.
-   */
-  [[nodiscard]] result<iterator> add_route(hal::can::id_t p_id) noexcept
-  {
-    auto result = m_messages.emplace(std::make_pair(
-      p_id, []([[maybe_unused]] const can::message_t& p_message) {}));
-    auto was_successful = result.second;
-
-    if (!was_successful) {
-      return hal::new_error(std::errc::not_enough_memory);
-    }
-
-    if (!m_initialized) {
-      m_initialized = true;
-      HAL_CHECK(m_can->on_receive([this](const can::message_t& p_message) {
-        auto router_pair = m_messages.find(p_message.id);
-        if (router_pair != m_messages.end()) {
-          router_pair->second(p_message);
-        }
-      }));
-    }
-
-    return result.first;
-  }
+  can_router() = delete;
+  can_router(can_router& p_other_self) = delete;
+  can_router& operator=(can_router& p_other_self) = delete;
+  can_router(can_router&& p_other_self) = default;
+  can_router& operator=(can_router&& p_other_self) = default;
 
   /**
-   * @brief Set a callback for when messages with a specific ID is received
+   * @brief Get a reference to the can peripheral driver
    *
-   *
-   * @param p_id - Associated ID of messages to be stored.
-   * @param p_handler - callback to be executed when a p_id message is received.
-   * @return status - error or success
-   * @throws std::errc::not_enough_memory if the internal network map does not
-   * have enough space to add another handler.
-   */
-  [[nodiscard]] status on_receive(hal::can::id_t p_id,
-                                  handler p_handler) noexcept
-  {
-    auto iterator = HAL_CHECK(add_route(p_id));
-    iterator->second = p_handler;
-    return hal::success();
-  }
-
-  /**
-   * @brief get a reference to the can peripheral driver
-   *
-   * Can be used to initialize, configure, and enable the peripheral as well as
-   * transmit messages.
+   * Used to send can messages through the same port that the can_router is
+   * using.
    *
    * @return can& reference to the can peripheral driver
    */
@@ -99,22 +59,95 @@ public:
   }
 
   /**
-   * @brief Get the Internal Map object
+   * @brief Add a message route without setting the callback
+   *
+   * The default callback will do nothing and will drop the message.
+   *
+   * @param p_id - Associated ID of messages to be stored.
+   * @return auto - route item from the linked list that must be stored stored
+   * in a variable
+   */
+  [[nodiscard]] auto add_message_callback(hal::can::id_t p_id) noexcept
+  {
+    return m_handlers.push_back(route{
+      .id = p_id,
+    });
+  }
+
+  /**
+   * @brief Set a callback for when messages with a specific ID is received
+   *
+   * @param p_id - Associated ID of messages to be stored.
+   * @param p_handler - callback to be executed when a p_id message is received.
+   * @return auto - route item from the linked list that must be stored stored
+   * in a variable
+   */
+  [[nodiscard]] auto add_message_callback(hal::can::id_t p_id,
+                                          message_handler p_handler) noexcept
+  {
+    return m_handlers.push_back(route{
+      .id = p_id,
+      .handler = p_handler,
+    });
+  }
+
+  /**
+   * @brief Get the list of handlers
    *
    * Meant for testing purposes or when direct inspection of the map is useful
    * in userspace. Should not be used in by libraries.
    *
-   * @return const auto& map of all of the messages in the network.
+   * @return const auto& map of all of the can message handlers.
    */
-  [[nodiscard]] const auto& get_internal_map() noexcept
+  [[nodiscard]] const auto& handlers() noexcept
   {
-    return m_messages;
+    return m_handlers;
+  }
+
+  /**
+   * @brief Message routing interrupt service handler
+   *
+   * Searches the static list and finds the first ID associated with the message
+   * and run's that route's callback.
+   *
+   * @param p_message - message received from the bus
+   */
+  void operator()(const can::message_t& p_message)
+  {
+    for (auto& list_handler : m_handlers) {
+      if (p_message.id == list_handler.id) {
+        list_handler.handler(p_message);
+        return;
+      }
+    }
   }
 
 private:
-  hal::can* m_can{};
-  route_map m_messages{};
-  bool m_initialized = false;
+  /**
+   * @brief Update the callback location if this object is moved
+   *
+   * @param p_old_self - the old version of the can_router
+   */
+  void intercept(can_router* p_old_self)
+  {
+    // Assume that if this succeeded in the create factory function, that it
+    // will work this time
+    (void)p_old_self->m_can->on_receive(std::ref(*this));
+  }
+
+  /**
+   * @brief Construct a new can message router
+   *
+   * @param p_can - can peripheral to route messages for
+   * @param p_memory_resource - memory resource used for storing callbacks
+   */
+  explicit can_router(hal::can& p_can) noexcept
+    : m_can(&p_can)
+  {
+  }
+
+  hal::static_list<route> m_handlers;
+  hal::can* m_can;
 };
 /** @} */
 }  // namespace hal

--- a/include/libhal/move_interceptor.hpp
+++ b/include/libhal/move_interceptor.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+namespace hal {
+/**
+ * @addtogroup utility
+ * @{
+ */
+/**
+ * @brief Use this to perform changes on an object its move constructor is
+ * executed.
+ *
+ * This can be used to allow type T to use a default move constructor but allow
+ * specific operations to occur beforehand. This is used for moveable objects
+ * with callbacks that refer back to their object's address such as the
+ * following:
+ *
+ *     this->obj->set_callback([this]() { foo(); });
+ *
+ * The default move constructor does everything correctly for type T. But the
+ * address of "this" in the lambda expression refers to the previous object's
+ * address which is no longer valid. Rather than a make a whole move constructor
+ * just to update this one callback, the move_interceptor can be used to change
+ * the previous object's callback to the new object's address before the move
+ * occurs. Then the object's default move constructor is executed.
+ *
+ * @tparam T - object to intercept the move constructor of
+ */
+template<class T>
+struct move_interceptor
+{
+  /**
+   * @brief Function called prior to type T's move constructor
+   *
+   * T must have a function named `T::intercept(T* p_previous)`.
+   *
+   * @param p_previous - pointer to the previous object that will be moved to
+   * the new object.
+   */
+  void intercept(T* p_previous)
+  {
+    static_cast<T*>(this)->intercept(p_previous);
+  }
+
+  move_interceptor() = default;
+  move_interceptor(move_interceptor& p_previous) = delete;
+  move_interceptor& operator=(move_interceptor& p_previous) = delete;
+  move_interceptor(move_interceptor&& p_previous)
+  {
+    intercept(static_cast<T*>(&p_previous));
+  }
+  move_interceptor& operator=(move_interceptor&& p_previous)
+  {
+    intercept(static_cast<T*>(&p_previous));
+    return *this;
+  }
+};
+/** @} */
+}  // namespace hal

--- a/include/libhal/static_callable.hpp
+++ b/include/libhal/static_callable.hpp
@@ -45,7 +45,8 @@ public:
    * @param p_callback - when the static callback function is called, it will
    * call this callback
    */
-  static_callable(std::function<return_t(args_t... p_args)> p_callback) noexcept
+  explicit static_callable(
+    std::function<return_t(args_t... p_args)> p_callback) noexcept
   {
     callback = p_callback;
   }

--- a/include/libhal/static_list.hpp
+++ b/include/libhal/static_list.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <utility>
 
 namespace hal {
@@ -191,7 +192,13 @@ public:
   public:
     friend class static_list;
 
-    item_iterator(item* p_item, static_list* p_list = nullptr)
+    using iterator_category = std::bidirectional_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = Object;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    explicit item_iterator(item* p_item, const static_list* p_list = nullptr)
       : m_self(p_item)
       , m_list(p_list)
     {
@@ -234,19 +241,34 @@ public:
       return m_self == p_other.m_self;
     }
 
-    Object& operator*()
+    bool operator!=(const item_iterator& p_other) const
+    {
+      return m_self != p_other.m_self;
+    }
+
+    reference operator*()
     {
       return m_self->get();
     }
 
-    const Object& operator*() const
+    const reference operator*() const
     {
       return m_self->get();
+    }
+
+    pointer operator->()
+    {
+      return &m_self->get();
+    }
+
+    pointer operator->() const
+    {
+      return &m_self->get();
     }
 
   private:
     item* m_self;
-    static_list* m_list;
+    const static_list* m_list;
   };
 
   using value_type = Object;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(${PROJECT_NAME}
   static_callable.test.cpp
   testing.test.cpp
   main.test.cpp
+  move_interceptor.test.cpp
   overflow_counter.test.cpp
   math.test.cpp
   error.test.cpp

--- a/tests/can/router.test.cpp
+++ b/tests/can/router.test.cpp
@@ -1,1 +1,274 @@
 #include <libhal/can/router.hpp>
+
+#include <algorithm>
+#include <boost/ut.hpp>
+
+namespace hal {
+namespace {
+class mock_can : public hal::can
+{
+public:
+  settings m_settings{};
+  message_t m_message{};
+  std::function<handler> m_handler{};
+  bool m_return_error_status{ false };
+
+private:
+  status driver_configure(const settings& p_settings) noexcept override
+  {
+    m_settings = p_settings;
+    if (m_return_error_status) {
+      return hal::new_error();
+    }
+    return success();
+  };
+
+  status driver_send(const message_t& p_message) noexcept override
+  {
+    m_message = p_message;
+    if (m_return_error_status) {
+      return hal::new_error();
+    }
+    return success();
+  };
+
+  status driver_on_receive(std::function<handler> p_handler) noexcept override
+  {
+    m_handler = p_handler;
+    if (m_return_error_status) {
+      return hal::new_error();
+    }
+    return success();
+  };
+};
+}  // namespace
+
+boost::ut::suite can_router_test = []() {
+  using namespace boost::ut;
+
+  "can_router::create + update_callback()"_test = []() {
+    // Setup
+    mock_can mock;
+
+    // Exercise
+    auto router = can_router::create(mock);
+
+    // Verify
+    expect(bool{ router });
+  };
+
+  "can_router::create failure"_test = []() {
+    // Setup
+    mock_can mock;
+    mock.m_return_error_status = true;
+
+    // Exercise
+    auto router = can_router::create(mock);
+
+    // Verify
+    expect(!bool{ router });
+  };
+
+  "can_router::bus()"_test = []() {
+    // Setup
+    static constexpr can::message_t expected{
+      .id = 0x111,
+      .payload = { 0xAA, 0xBB, 0xCC },
+      .length = 3,
+    };
+    mock_can mock;
+    auto router = can_router::create(mock).value();
+
+    // Exercise
+    auto status = router.bus().send(expected);
+
+    // Verify
+    expect(bool{ status });
+    expect(expected == mock.m_message);
+  };
+
+  "can_router::bus() failed"_test = []() {
+    // Setup
+    static constexpr can::message_t expected{
+      .id = 0x111,
+      .payload = { 0xAA, 0xBB, 0xCC },
+      .length = 3,
+    };
+    mock_can mock;
+    auto router = can_router::create(mock).value();
+    mock.m_return_error_status = true;
+
+    // Exercise
+    auto status = router.bus().send(expected);
+
+    // Verify
+    expect(!bool{ status });
+    expect(expected == mock.m_message);
+  };
+
+  "can_router::add_message_callback(id)"_test = []() {
+    // Setup
+    static constexpr can::id_t id = 0x15;
+    mock_can mock;
+    auto router = can_router::create(mock).value();
+
+    // Exercise
+    auto callback_item = router.add_message_callback(id);
+
+    // Verify
+    expect(that % id == callback_item.get().id);
+    expect(that % 1 == router.handlers().size());
+
+    [[maybe_unused]] const auto& iterator = std::find_if(
+      router.handlers().begin(),
+      router.handlers().cend(),
+      [](const can_router::route& p_route) { return p_route.id == id; });
+    expect(iterator->id == callback_item.get().id);
+  };
+
+  "can_router::add_message_callback(id, callback)"_test = []() {
+    // Setup
+    static constexpr can::id_t id = 0x15;
+    static constexpr can::message_t expected{
+      .id = 0x111,
+      .payload = { 0xAA, 0xBB, 0xCC },
+      .length = 3,
+    };
+    mock_can mock;
+    auto router = can_router::create(mock).value();
+    int counter = 0;
+    can::message_t actual{};
+
+    // Exercise
+    auto callback_item = router.add_message_callback(
+      id,
+      [&counter, &actual]([[maybe_unused]] const can::message_t& p_message) {
+        counter++;
+        actual = p_message;
+      });
+
+    [[maybe_unused]] const auto& iterator = std::find_if(
+      router.handlers().begin(),
+      router.handlers().cend(),
+      [](const can_router::route& p_route) { return p_route.id == id; });
+
+    iterator->handler(expected);
+
+    // Verify
+    expect(that % id == callback_item.get().id);
+    expect(that % 1 == router.handlers().size());
+    expect(iterator->id == callback_item.get().id);
+    expect(that % 1 == counter);
+    expect(expected == actual);
+  };
+
+  "can_router::add_message_callback(id, callback)"_test = []() {
+    // Setup
+    mock_can mock;
+    auto router = can_router::create(mock).value();
+    int counter1 = 0;
+    int counter2 = 0;
+    int counter3 = 0;
+    static constexpr can::message_t expected1{
+      .id = 0x100,
+      .payload = { 0xAA, 0xBB },
+      .length = 2,
+    };
+    static constexpr can::message_t expected2{
+      .id = 0x120,
+      .payload = { 0xCC, 0xDD },
+      .length = 2,
+    };
+    static constexpr can::message_t expected3{
+      .id = 0x123,
+      .payload = { 0xEE, 0xFF },
+      .length = 2,
+    };
+
+    can::message_t actual1{};
+    can::message_t actual2{};
+    can::message_t actual3{};
+
+    auto message_handler1 = router.add_message_callback(
+      expected1.id,
+      [&counter1, &actual1]([[maybe_unused]] const can::message_t& p_message) {
+        counter1++;
+        actual1 = p_message;
+      });
+
+    auto message_handler2 = router.add_message_callback(
+      expected2.id,
+      [&counter2, &actual2]([[maybe_unused]] const can::message_t& p_message) {
+        counter2++;
+        actual2 = p_message;
+      });
+
+    auto message_handler3 = router.add_message_callback(
+      expected3.id,
+      [&counter3, &actual3]([[maybe_unused]] const can::message_t& p_message) {
+        counter3++;
+        actual3 = p_message;
+      });
+
+    // Exercise
+    router(expected1);
+
+    // Verify
+    expect(that % 3 == router.handlers().size());
+    expect(that % 1 == counter1);
+    expect(expected1 == actual1);
+    expect(that % 0 == counter2);
+    expect(expected2 != actual2);
+    expect(that % 0 == counter2);
+    expect(expected3 != actual3);
+
+    router(expected2);
+
+    expect(that % 1 == counter1);
+    expect(expected1 == actual1);
+    expect(that % 1 == counter2);
+    expect(expected2 == actual2);
+    expect(that % 0 == counter3);
+    expect(expected3 != actual3);
+
+    router(expected3);
+
+    expect(that % 1 == counter1);
+    expect(expected1 == actual1);
+    expect(that % 1 == counter2);
+    expect(expected2 == actual2);
+    expect(that % 1 == counter2);
+    expect(expected3 == actual3);
+
+    router(expected2);
+
+    expect(that % 1 == counter1);
+    expect(expected1 == actual1);
+    expect(that % 2 == counter2);
+    expect(expected2 == actual2);
+    expect(that % 1 == counter3);
+    expect(expected3 == actual3);
+
+    message_handler2.~item();
+    expect(that % 2 == router.handlers().size());
+
+    router(expected2);
+
+    expect(that % 1 == counter1);
+    expect(expected1 == actual1);
+    expect(that % 2 == counter2);  // stays the same
+    expect(expected2 == actual2);
+    expect(that % 1 == counter3);
+    expect(expected3 == actual3);
+
+    router(expected3);
+
+    expect(that % 1 == counter1);
+    expect(expected1 == actual1);
+    expect(that % 2 == counter2);
+    expect(expected2 == actual2);
+    expect(that % 2 == counter2);
+    expect(expected3 == actual3);
+  };
+};
+}  // namespace hal

--- a/tests/move_interceptor.test.cpp
+++ b/tests/move_interceptor.test.cpp
@@ -1,0 +1,51 @@
+#include <libhal/move_interceptor.hpp>
+
+#include <boost/ut.hpp>
+
+namespace hal {
+boost::ut::suite move_interceptor_test = []() {
+  using namespace boost::ut;
+
+  "move_interceptor<mock>::intercept"_test = []() {
+    struct mock : public move_interceptor<mock>
+    {
+      mock() = default;
+      mock(mock&) = default;
+      mock& operator=(mock&) = default;
+      mock& operator=(mock&& p_old_self) = default;
+      mock(mock&& p_old_self) = default;
+
+      void intercept(mock* p_old_self)
+      {
+        p_old_self->count++;
+      }
+
+      bool* intercept_was_called_first_ptr;
+      int count = 0;
+    };
+
+    // Setup
+    mock mock1;
+
+    // Exercise
+    auto mock2 = std::move(mock1);
+    // Verify
+    expect(that % 1 == mock2.count);
+
+    // Exercise
+    auto mock3 = std::move(mock2);
+    // Verify
+    expect(that % 2 == mock3.count);
+
+    // Exercise
+    auto mock4 = std::move(mock3);
+    // Verify
+    expect(that % 3 == mock4.count);
+
+    // Exercise
+    auto mock5 = std::move(mock4);
+    // Verify
+    expect(that % 4 == mock5.count);
+  };
+};
+}  // namespace hal


### PR DESCRIPTION
- Add comparison operator for can::message_t
- Add move_interceptor
- Add type traits for static_list::item_iterator to allow it to be used
  by the standard algorithms

Resolves https://github.com/libhal/libhal/issues/38