### PR TITLE
Add spy_handler::history<N>(M)

### DIFF
--- a/include/libhal/testing.hpp
+++ b/include/libhal/testing.hpp
@@ -73,6 +73,19 @@ public:
   }
 
   /**
+   * @brief Return argument from one of call history parameters
+   *
+   * @param p_call - history call from 0 to N
+   * @return const auto& - reference to the call history vector
+   * @throws std::out_of_range - if p_call is beyond the size of call_history
+   */
+  template<size_t ArgumentIndex>
+  const auto& history(int p_call) const noexcept
+  {
+    return std::get<ArgumentIndex>(m_call_history.at(p_call));
+  }
+
+  /**
    * @brief Reset call recordings and turns off error trigger
    *
    */

--- a/tests/testing.test.cpp
+++ b/tests/testing.test.cpp
@@ -12,71 +12,119 @@ boost::ut::suite testing_utilities_test = []() {
   spy.trigger_error_on_call(4);
 
   expect(bool{ spy.record(1, 'A') });
+
   expect(that % 1 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
+  expect(that % 1 == spy.history<0>(0));
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
+  expect(that % 'A' == spy.history<1>(0));
 
   expect(bool{ spy.record(2, 'B') });
+
   expect(that % 2 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
+  expect(that % 1 == spy.history<0>(0));
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
+  expect(that % 'A' == spy.history<1>(0));
   expect(that % 2 == std::get<0>(spy.call_history().at(1)));
+  expect(that % 2 == spy.history<0>(1));
   expect(that % 'B' == std::get<1>(spy.call_history().at(1)));
+  expect(that % 'B' == spy.history<1>(1));
 
   expect(bool{ spy.record(3, 'C') });
+
   expect(that % 3 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
+  expect(that % 1 == spy.history<0>(0));
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
+  expect(that % 'A' == spy.history<1>(0));
   expect(that % 2 == std::get<0>(spy.call_history().at(1)));
+  expect(that % 2 == spy.history<0>(1));
   expect(that % 'B' == std::get<1>(spy.call_history().at(1)));
+  expect(that % 'B' == spy.history<1>(1));
   expect(that % 3 == std::get<0>(spy.call_history().at(2)));
+  expect(that % 3 == spy.history<0>(2));
   expect(that % 'C' == std::get<1>(spy.call_history().at(2)));
+  expect(that % 'C' == spy.history<1>(2));
 
   expect(!spy.record(4, 'D'));
+
   expect(that % 4 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
+  expect(that % 1 == spy.history<0>(0));
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
+  expect(that % 'A' == spy.history<1>(0));
   expect(that % 2 == std::get<0>(spy.call_history().at(1)));
+  expect(that % 2 == spy.history<0>(1));
   expect(that % 'B' == std::get<1>(spy.call_history().at(1)));
+  expect(that % 'B' == spy.history<1>(1));
   expect(that % 3 == std::get<0>(spy.call_history().at(2)));
+  expect(that % 3 == spy.history<0>(2));
   expect(that % 'C' == std::get<1>(spy.call_history().at(2)));
+  expect(that % 'C' == spy.history<1>(2));
   expect(that % 4 == std::get<0>(spy.call_history().at(3)));
+  expect(that % 4 == spy.history<0>(3));
   expect(that % 'D' == std::get<1>(spy.call_history().at(3)));
+  expect(that % 'D' == spy.history<1>(3));
 
   spy.reset();
 
   expect(that % 0 == spy.call_history().size());
 
   expect(bool{ spy.record(1, 'A') });
+
   expect(that % 1 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
+  expect(that % 1 == spy.history<0>(0));
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
+  expect(that % 'A' == spy.history<1>(0));
 
   expect(bool{ spy.record(2, 'B') });
+
   expect(that % 2 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
+  expect(that % 1 == spy.history<0>(0));
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
+  expect(that % 'A' == spy.history<1>(0));
   expect(that % 2 == std::get<0>(spy.call_history().at(1)));
+  expect(that % 2 == spy.history<0>(1));
   expect(that % 'B' == std::get<1>(spy.call_history().at(1)));
+  expect(that % 'B' == spy.history<1>(1));
 
   expect(bool{ spy.record(3, 'C') });
+
   expect(that % 3 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
+  expect(that % 1 == spy.history<0>(0));
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
+  expect(that % 'A' == spy.history<1>(0));
   expect(that % 2 == std::get<0>(spy.call_history().at(1)));
+  expect(that % 2 == spy.history<0>(1));
   expect(that % 'B' == std::get<1>(spy.call_history().at(1)));
+  expect(that % 'B' == spy.history<1>(1));
   expect(that % 3 == std::get<0>(spy.call_history().at(2)));
+  expect(that % 3 == spy.history<0>(2));
   expect(that % 'C' == std::get<1>(spy.call_history().at(2)));
+  expect(that % 'C' == spy.history<1>(2));
 
   expect(bool{ spy.record(4, 'D') });
+
   expect(that % 4 == spy.call_history().size());
   expect(that % 1 == std::get<0>(spy.call_history().at(0)));
+  expect(that % 1 == spy.history<0>(0));
   expect(that % 'A' == std::get<1>(spy.call_history().at(0)));
+  expect(that % 'A' == spy.history<1>(0));
   expect(that % 2 == std::get<0>(spy.call_history().at(1)));
+  expect(that % 2 == spy.history<0>(1));
   expect(that % 'B' == std::get<1>(spy.call_history().at(1)));
+  expect(that % 'B' == spy.history<1>(1));
   expect(that % 3 == std::get<0>(spy.call_history().at(2)));
+  expect(that % 3 == spy.history<0>(2));
   expect(that % 'C' == std::get<1>(spy.call_history().at(2)));
+  expect(that % 'C' == spy.history<1>(2));
   expect(that % 4 == std::get<0>(spy.call_history().at(3)));
+  expect(that % 4 == spy.history<0>(3));
   expect(that % 'D' == std::get<1>(spy.call_history().at(3)));
+  expect(that % 'D' == spy.history<1>(3));
 };
 }  // namespace hal


### PR DESCRIPTION
A shorter way to get parameter history from spy_handler