### PR TITLE
Use iosfwd correctly for can::message_t

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.16"
+    version = "0.1.17"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/can/interface.hpp
+++ b/include/libhal/can/interface.hpp
@@ -200,12 +200,16 @@ public:
      * C++ streams, in general, should not be used for any embedded project that
      * will ever have to be used on an MCU due to its memory cost.
      *
+     * @tparam CharT - character type
+     * @tparam Traits - ostream traits type
      * @param p_ostream - the ostream
      * @param p_message - object to convert to a string
-     * @return std::ostream& - reference to the ostream
+     * @return std::basic_ostream<CharT, Traits>& - reference to the ostream
      */
-    friend std::ostream& operator<<(std::ostream& p_ostream,
-                                    const message_t& p_message)
+    template<class CharT, class Traits>
+    friend std::basic_ostream<CharT, Traits>& operator<<(
+      std::basic_ostream<CharT, Traits>& p_ostream,
+      const message_t& p_message)
     {
       p_ostream << "{ id: " << std::hex << "0x" << p_message.id;
       p_ostream << ", length: " << std::dec << unsigned{ p_message.length };


### PR DESCRIPTION
The stream operator must be (1) a template and (2) the generic basic_ostream type.

Templates will prevent the compiler from complaining if the forwarded types are not defined so long as the template function isn't used.

Using a basic_ostream type allows other ostream variants to be used rather than the built in std::ostream.