### PR TITLE
Add hal::skip_past(serial) functor

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,10 +21,6 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: 📥 Install clang-format
-        shell: bash
-        run: sudo apt install clang-format-13
-
       - name: 📥 Install libclang-11-dev (for name style check)
         shell: bash
         run: sudo apt install libclang-11-dev
@@ -55,8 +51,10 @@ jobs:
         run: wget https://raw.githubusercontent.com/libhal/libhal/main/.clang-format -O .clang-format
 
       - name: 🧹 Format Check
-        shell: bash
-        if: always()
-        run: |
-             clang-format --dry-run --Werror \
-             $(find include -name "*.hpp" -not -path "*/third_party/*")
+        uses: DoozyX/clang-format-lint-action@v0.14
+        with:
+          source: 'include/'
+          exclude: './third_party/*'
+          extensions: 'hpp,cpp'
+          clangFormatVersion: 14
+          style: file

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.17"
+    version = "0.1.18"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/callback_recorder.hpp
+++ b/include/libhal/callback_recorder.hpp
@@ -51,15 +51,12 @@ public:
    * @tparam U - return type of the callback function
    * @tparam V - type of the callback function
    * @param p_default - default value to return from callback function
-   * @param p_callback - when the static callback function is called, it will
-   * call this callback
    */
   template<typename U = return_t,
            typename V = std::enable_if_t<!std::is_void_v<U>>*>
-  callback_recorder(U p_default = U{}, V p_callback = 0) noexcept
+  callback_recorder(U p_default = U{}) noexcept
   {
-    m_callback =
-      [this, p_default, p_callback]([[maybe_unused]] args_t... p_args) -> U {
+    m_callback = [this, p_default]([[maybe_unused]] args_t... p_args) -> U {
       m_call_count++;
       return p_default;
     };

--- a/include/libhal/enum.hpp
+++ b/include/libhal/enum.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <iosfwd>
+#include <string_view>
 #include <type_traits>
 
 namespace hal {
@@ -7,6 +9,62 @@ namespace hal {
  * @addtogroup utility
  * @{
  */
+
+/**
+ * @brief Represents the state of a coroutine or resumable callable
+ *
+ */
+enum class work_state
+{
+  // Callable is in progress and has not yet finished performing its work
+  in_progress,
+  // Callable was able to determine that it failed to do what it was tasked to
+  // do.
+  failure,
+  // Callable completed the work it needed to perform
+  finished,
+};
+
+/**
+ * @brief Get string representation of the work state.
+ *
+ * @param p_state - work state
+ * @return std::string_view - string representation
+ */
+constexpr std::string_view to_string(work_state p_state)
+{
+  switch (p_state) {
+    case work_state::in_progress:
+      return "in progress";
+    case work_state::failure:
+      return "failure";
+    case work_state::finished:
+      return "finished";
+    default:
+      return "unknown work state";
+  }
+}
+
+/**
+ * @brief print work_state type using ostreams
+ *
+ * Meant for unit testing, testing and simulation purposes
+ * C++ streams, in general, should not be used for any embedded project that
+ * will ever have to be used on an MCU due to its memory cost.
+ *
+ * @tparam CharT - character type
+ * @tparam Traits - ostream traits type
+ * @param p_ostream - the ostream
+ * @param p_state - object to convert to a string
+ * @return std::basic_ostream<CharT, Traits>& - reference to the ostream
+ */
+template<class CharT, class Traits>
+inline std::basic_ostream<CharT, Traits>& operator<<(
+  std::basic_ostream<CharT, Traits>& p_ostream,
+  const work_state& p_state)
+{
+  return p_ostream << to_string(p_state);
+}
 
 /**
  * @brief concept for enumeration types

--- a/include/libhal/serial/coroutines.hpp
+++ b/include/libhal/serial/coroutines.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <optional>
+#include <span>
+
+#include "../as_bytes.hpp"
+#include "../comparison.hpp"
+#include "../enum.hpp"
+#include "../error.hpp"
+#include "../timeout.hpp"
+#include "../units.hpp"
+#include "interface.hpp"
+
+namespace hal {
+
+/**
+ * @brief Discard received bytes until the sequence is found
+ *
+ */
+class skip_past
+{
+public:
+  /**
+   * @brief Construct a new skip beyond object
+   *
+   * @param p_serial - serial port to skip through
+   * @param p_sequence - sequence to search for. The lifetime of this data
+   * pointed to by this span must outlive this object, or not be used when the
+   * lifetime of that data is no longer available.
+   * @param p_read_limit - the maximum number of bytes to read off from the
+   * serial port before returning. A value 0 will result in no reads from the
+   * serial port.
+   */
+  skip_past(serial& p_serial,
+            std::span<const hal::byte> p_sequence,
+            size_t p_read_limit = 32)
+    : m_serial(&p_serial)
+    , m_sequence(p_sequence)
+    , m_read_limit(p_read_limit)
+  {
+  }
+
+  /**
+   * @brief
+   *
+   * @return result<work_state> - only
+   */
+  result<work_state> operator()()
+  {
+    if (m_search_index == m_sequence.size()) {
+      return work_state::finished;
+    }
+
+    for (size_t read_limit = 0; read_limit < m_read_limit; read_limit++) {
+      std::array<hal::byte, 1> buffer;
+      auto read_result = HAL_CHECK(m_serial->read(buffer));
+
+      if (read_result.received.size() != buffer.size()) {
+        return work_state::in_progress;
+      }
+
+      // Check if the next byte received matches the sequence
+      if (m_sequence[m_search_index] == read_result.received[0]) {
+        m_search_index++;
+      } else {  // Otherwise set the search index back to the start.
+        m_search_index = 0;
+      }
+
+      // Check if the search index is equal to the size of the sequence size
+      if (m_search_index == m_sequence.size()) {
+        return work_state::finished;
+      }
+    }
+
+    return work_state::in_progress;
+  }
+
+private:
+  serial* m_serial;
+  std::span<const hal::byte> m_sequence;
+  size_t m_search_index = 0;
+  size_t m_read_limit;
+};
+}  // namespace hal

--- a/include/libhal/serial/util.hpp
+++ b/include/libhal/serial/util.hpp
@@ -6,6 +6,7 @@
 
 #include "../as_bytes.hpp"
 #include "../comparison.hpp"
+#include "../enum.hpp"
 #include "../error.hpp"
 #include "../timeout.hpp"
 #include "../units.hpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,8 @@ add_executable(${PROJECT_NAME}
   serial/util.test.cpp
   steady_clock/util.test.cpp
 
+  serial/coroutine.test.cpp
+
   motor/mock.test.cpp
   pwm/mock.test.cpp
   timer/mock.test.cpp

--- a/tests/serial/coroutine.test.cpp
+++ b/tests/serial/coroutine.test.cpp
@@ -1,0 +1,344 @@
+#include <libhal/serial/coroutines.hpp>
+
+#include <boost/ut.hpp>
+#include <libhal/testing.hpp>
+#include <span>
+
+namespace hal {
+boost::ut::suite serial_coroutine_test = []() {
+  using namespace boost::ut;
+
+  class fake_serial : public hal::serial
+  {
+  public:
+    status driver_configure(const settings&) noexcept override
+    {
+      return {};
+    }
+
+    result<write_t> driver_write(
+      std::span<const hal::byte> p_data) noexcept override
+    {
+      return write_t{
+        .transmitted = p_data,
+        .remaining = std::span<const hal::byte>(),
+      };
+    }
+
+    result<read_t> driver_read(std::span<hal::byte> p_data) noexcept override
+    {
+      return m_read_function(p_data);
+    }
+
+    status driver_flush() noexcept override
+    {
+      return {};
+    }
+
+    virtual ~fake_serial()
+    {
+    }
+
+    std::function<result<read_t>(std::span<hal::byte>)> m_read_function;
+  };
+
+  const std::array<hal::byte, 6> read_out{ 1, 2, 3, 4, 5, 6 };
+  const std::array<hal::byte, 3> sequence{ 3, 4, 5 };
+
+  "[success] skip_past one shot"_test = [=]() {
+    // Setup
+    fake_serial serial;
+    serial.m_read_function =
+      [&read_out, count = size_t(0)](
+        std::span<hal::byte> p_data) mutable -> result<serial::read_t> {
+      if (count < read_out.size()) {
+        p_data[0] = read_out[count++];
+
+        return serial::read_t{
+          .received = p_data.subspan(0, 1),
+          .remaining = p_data.subspan(1),
+          .available = 1,
+          .capacity = 1,
+        };
+      }
+
+      return serial::read_t{
+        .received = p_data.subspan(0, 0),
+        .remaining = std::span<hal::byte>(),
+        .available = 1,
+        .capacity = 1,
+      };
+    };
+
+    auto skipper = skip_past(serial, sequence);
+    std::array<work_state, 5> actual;
+
+    // Exercise
+    actual[0] = skipper().value();
+    actual[1] = skipper().value();
+    actual[2] = skipper().value();
+    actual[3] = skipper().value();
+    actual[4] = skipper().value();
+
+    // Verify
+    expect(that % work_state::finished == actual[0]);
+    expect(that % work_state::finished == actual[1]);
+    expect(that % work_state::finished == actual[2]);
+    expect(that % work_state::finished == actual[3]);
+    expect(that % work_state::finished == actual[4]);
+  };
+
+  "[success] skip_past one byte at a time"_test = [=]() {
+    // Setup
+    fake_serial serial;
+    serial.m_read_function =
+      [&read_out, count = size_t(0), send_byte = false](
+        std::span<hal::byte> p_data) mutable -> result<serial::read_t> {
+      send_byte = !send_byte;
+
+      if (send_byte) {
+        if (count < read_out.size()) {
+          p_data[0] = read_out[count++];
+
+          return serial::read_t{
+            .received = p_data.subspan(0, 1),
+            .remaining = p_data.subspan(1),
+            .available = 1,
+            .capacity = 1,
+          };
+        }
+      }
+      return serial::read_t{
+        .received = p_data.subspan(0, 0),
+        .remaining = std::span<hal::byte>(),
+        .available = 1,
+        .capacity = 1,
+      };
+    };
+
+    auto skipper = skip_past(serial, sequence);
+    std::array<work_state, 5> actual;
+
+    // Exercise
+    actual[0] = skipper().value();
+    actual[1] = skipper().value();
+    actual[2] = skipper().value();
+    actual[3] = skipper().value();
+    actual[4] = skipper().value();
+
+    // Verify
+    expect(that % work_state::in_progress == actual[0]);
+    expect(that % work_state::in_progress == actual[1]);
+    expect(that % work_state::in_progress == actual[2]);
+    expect(that % work_state::in_progress == actual[3]);
+    expect(that % work_state::finished == actual[4]);
+  };
+
+  "[success] skip_past in two blocks"_test = [=]() {
+    // Setup
+    fake_serial serial;
+    serial.m_read_function =
+      [&read_out, count = size_t(0)](
+        std::span<hal::byte> p_data) mutable -> result<serial::read_t> {
+      serial::read_t read_response{};
+
+      switch (count) {
+        case 0:
+        case 1:
+          p_data[0] = read_out[count];
+          read_response = serial::read_t{
+            .received = p_data.subspan(0, 1),
+            .remaining = p_data.subspan(1),
+            .available = 1,
+            .capacity = 1,
+          };
+          break;
+        case 2:
+          read_response = serial::read_t{
+            .received = p_data.subspan(0, 0),
+            .remaining = std::span<hal::byte>(),
+            .available = 1,
+            .capacity = 1,
+          };
+          break;
+        case 3:
+          p_data[0] = read_out[count - 1];
+          read_response = serial::read_t{
+            .received = p_data.subspan(0, 1),
+            .remaining = p_data.subspan(1),
+            .available = 1,
+            .capacity = 1,
+          };
+          break;
+        case 4:
+          read_response = serial::read_t{
+            .received = p_data.subspan(0, 0),
+            .remaining = std::span<hal::byte>(),
+            .available = 1,
+            .capacity = 1,
+          };
+          break;
+        case 5:
+        case 6:
+        case 7:
+          p_data[0] = read_out[count - 2];
+          read_response = serial::read_t{
+            .received = p_data.subspan(0, 1),
+            .remaining = p_data.subspan(1),
+            .available = 1,
+            .capacity = 1,
+          };
+          break;
+        default:
+          read_response = serial::read_t{
+            .received = p_data.subspan(0, 0),
+            .remaining = std::span<hal::byte>(),
+            .available = 1,
+            .capacity = 1,
+          };
+      }
+      count++;
+      return read_response;
+    };
+
+    auto skipper = skip_past(serial, sequence);
+    std::array<work_state, 5> actual;
+
+    // Exercise
+    actual[0] = skipper().value();
+    actual[1] = skipper().value();
+    actual[2] = skipper().value();
+    actual[3] = skipper().value();
+    actual[4] = skipper().value();
+
+    // Verify
+    expect(that % work_state::in_progress == actual[0]);
+    expect(that % work_state::in_progress == actual[1]);
+    expect(that % work_state::finished == actual[2]);
+    expect(that % work_state::finished == actual[3]);
+    expect(that % work_state::finished == actual[4]);
+  };
+
+  "[success] skip_past return control after 1 byte"_test = [=]() {
+    // Setup
+    fake_serial serial;
+    serial.m_read_function =
+      [&read_out, count = size_t(0)](
+        std::span<hal::byte> p_data) mutable -> result<serial::read_t> {
+      if (count < read_out.size()) {
+        p_data[0] = read_out[count++];
+
+        return serial::read_t{
+          .received = p_data.subspan(0, 1),
+          .remaining = p_data.subspan(1),
+          .available = 1,
+          .capacity = 1,
+        };
+      }
+
+      return serial::read_t{
+        .received = p_data.subspan(0, 0),
+        .remaining = std::span<hal::byte>(),
+        .available = 1,
+        .capacity = 1,
+      };
+    };
+
+    auto skipper = skip_past(serial, sequence, 1);
+    std::array<work_state, 6> actual;
+
+    // Exercise
+    actual[0] = skipper().value();
+    actual[1] = skipper().value();
+    actual[2] = skipper().value();
+    actual[3] = skipper().value();
+    actual[4] = skipper().value();
+    actual[5] = skipper().value();
+
+    // Verify
+    expect(that % work_state::in_progress == actual[0]);
+    expect(that % work_state::in_progress == actual[1]);
+    expect(that % work_state::in_progress == actual[2]);
+    expect(that % work_state::in_progress == actual[3]);
+    expect(that % work_state::finished == actual[4]);
+    expect(that % work_state::finished == actual[5]);
+  };
+
+  "[failure] skip_past return error on read"_test = [=]() {
+    // Setup
+    fake_serial serial;
+    serial.m_read_function =
+      []([[maybe_unused]] std::span<hal::byte> p_data) mutable
+      -> result<serial::read_t> { return hal::new_error(); };
+
+    auto skipper = skip_past(serial, sequence);
+
+    // Exercise
+    auto actual = skipper();
+
+    // Verify
+    expect(that % false == bool(actual));
+  };
+
+  "[success] skip_past error every other byte"_test = [=]() {
+    // Setup
+    fake_serial serial;
+    serial.m_read_function =
+      [&read_out, count = size_t(0), send_byte = false](
+        std::span<hal::byte> p_data) mutable -> result<serial::read_t> {
+      send_byte = !send_byte;
+
+      if (send_byte) {
+        if (count < read_out.size()) {
+          p_data[0] = read_out[count++];
+
+          return serial::read_t{
+            .received = p_data.subspan(0, 1),
+            .remaining = p_data.subspan(1),
+            .available = 1,
+            .capacity = 1,
+          };
+        }
+      }
+
+      return hal::new_error();
+    };
+
+    auto skipper = skip_past(serial, sequence, 1);
+
+    // Exercise
+    auto actual0 = skipper();
+    auto actual1 = skipper();
+    auto actual2 = skipper();
+    auto actual3 = skipper();
+    auto actual4 = skipper();
+    auto actual5 = skipper();
+    auto actual6 = skipper();
+    auto actual7 = skipper();
+    auto actual8 = skipper();
+    auto actual9 = skipper();
+    auto actual10 = skipper();
+
+    // Verify
+    expect(that % true == actual0.has_value());
+    expect(that % false == actual1.has_value());
+    expect(that % true == actual2.has_value());
+    expect(that % false == actual3.has_value());
+    expect(that % true == actual4.has_value());
+    expect(that % false == actual5.has_value());
+    expect(that % true == actual6.has_value());
+    expect(that % false == actual7.has_value());
+    expect(that % true == actual8.has_value());  // finished
+    expect(that % true == actual9.has_value());  // can no longer error out
+                                                 // because this is finished.
+    expect(that % true == actual10.has_value());
+
+    expect(that % work_state::in_progress == actual0.value());
+    expect(that % work_state::in_progress == actual2.value());
+    expect(that % work_state::in_progress == actual4.value());
+    expect(that % work_state::in_progress == actual6.value());
+    expect(that % work_state::finished == actual8.value());
+    expect(that % work_state::finished == actual10.value());
+  };
+};
+}  // namespace hal

--- a/tests/serial/util.test.cpp
+++ b/tests/serial/util.test.cpp
@@ -1,8 +1,8 @@
-#include <boost/ut.hpp>
 #include <libhal/serial/util.hpp>
-#include <span>
 
+#include <boost/ut.hpp>
 #include <libhal/testing.hpp>
+#include <span>
 
 namespace hal {
 boost::ut::suite serial_util_test = []() {
@@ -14,12 +14,12 @@ boost::ut::suite serial_util_test = []() {
   class fake_serial : public hal::serial
   {
   public:
-    [[nodiscard]] status driver_configure(const settings&) noexcept override
+    status driver_configure(const settings&) noexcept override
     {
       return {};
     }
 
-    [[nodiscard]] result<write_t> driver_write(
+    result<write_t> driver_write(
       std::span<const hal::byte> p_data) noexcept override
     {
       write_call_count++;
@@ -34,8 +34,7 @@ boost::ut::suite serial_util_test = []() {
       return write_t{ p_data, std::span<const hal::byte>{} };
     }
 
-    [[nodiscard]] result<read_t> driver_read(
-      std::span<hal::byte> p_data) noexcept override
+    result<read_t> driver_read(std::span<hal::byte> p_data) noexcept override
     {
       if (p_data.size() == 0) {
         return read_t{
@@ -45,10 +44,13 @@ boost::ut::suite serial_util_test = []() {
           .capacity = 1,
         };
       }
+
       read_was_called = true;
+
       if (read_fails) {
         return hal::new_error();
       }
+
       // only fill 1 byte at a time
       p_data[0] = filler_byte;
 
@@ -60,7 +62,7 @@ boost::ut::suite serial_util_test = []() {
       };
     }
 
-    [[nodiscard]] status driver_flush() noexcept override
+    status driver_flush() noexcept override
     {
       flush_called = true;
       return {};


### PR DESCRIPTION
Skips bytes receieved on the serial port until a specified sequence is found. It is non-blocking in that it will not wait for data to come in there isn't any available. It also has a read limit, to adjust how many bytes of data to read before giving control back to the caller.

With each call to the functor, it will parse more data out of the serial port until it finds the sequence. At which point it will no longer read data from the serial port and will always return finished.

Resolves #526