### PR TITLE
Remove "remaining" from serial structs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.24"
+    version = "0.1.25"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/serial/coroutines.hpp
+++ b/include/libhal/serial/coroutines.hpp
@@ -63,12 +63,12 @@ public:
       std::array<hal::byte, 1> buffer;
       auto read_result = HAL_CHECK(m_serial->read(buffer));
 
-      if (read_result.received.size() != buffer.size()) {
+      if (read_result.data.size() != buffer.size()) {
         return work_state::in_progress;
       }
 
       // Check if the next byte received matches the sequence
-      if (m_sequence[m_search_index] == read_result.received[0]) {
+      if (m_sequence[m_search_index] == read_result.data[0]) {
         m_search_index++;
       } else {  // Otherwise set the search index back to the start.
         m_search_index = 0;
@@ -136,9 +136,9 @@ public:
 
       auto read_result = HAL_CHECK(m_serial->read(m_buffer));
       // Set the m_buffer to the amount of bytes remaining to be read.
-      m_buffer = read_result.remaining;
+      m_buffer = m_buffer.subspan(read_result.data.size());
 
-      if (read_result.received.empty()) {
+      if (read_result.data.empty()) {
         return work_state::in_progress;
       }
     }
@@ -211,12 +211,12 @@ public:
       auto read_result =
         HAL_CHECK(m_serial->read(m_buffer.subspan(0, read_length)));
 
-      if (read_result.received.size() == 0) {
+      if (read_result.data.size() == 0) {
         return work_state::in_progress;
       }
 
       // Check if the next byte received matches the sequence
-      if (m_sequence[m_search_index] == read_result.received[0]) {
+      if (m_sequence[m_search_index] == read_result.data[0]) {
         m_search_index++;
       } else {  // Otherwise set the search index back to the start.
         m_search_index = 0;
@@ -288,13 +288,13 @@ public:
       std::array<hal::byte, 1> buffer;
       auto read_result = HAL_CHECK(m_serial->read(buffer));
 
-      if (read_result.received.size() != buffer.size()) {
+      if (read_result.data.size() != buffer.size()) {
         return work_state::in_progress;
       }
 
-      if (std::isdigit(static_cast<char>(read_result.received[0]))) {
+      if (std::isdigit(static_cast<char>(read_result.data[0]))) {
         m_integer_value *= 10;
-        m_integer_value += read_result.received[0] - hal::byte('0');
+        m_integer_value += read_result.data[0] - hal::byte('0');
         m_found_digit = true;
       } else if (m_found_digit) {
         m_finished = true;

--- a/include/libhal/serial/interface.hpp
+++ b/include/libhal/serial/interface.hpp
@@ -103,15 +103,7 @@ public:
     /// The size of this buffer indicates the number of bytes read
     /// The address points to the start of the buffer passed into the read()
     /// function.
-    std::span<hal::byte> received;
-
-    /// @brief The unfilled portion of the buffer
-    ///
-    /// The size of this buffer indicates the number of bytes unfilled
-    /// The address points to right after the `data` span. This means that
-    /// putting the `remaining` buffer back into the read() until it reaches 0
-    /// will ensure that the entire original buffer is filled to capacity.
-    std::span<hal::byte> remaining;
+    std::span<hal::byte> data;
 
     /// @brief Number of enqueued and available to be read out bytes
     ///
@@ -134,15 +126,7 @@ public:
     /// The size of this buffer indicates the number of bytes read
     /// The address points to the start of the buffer passed into the read()
     /// function.
-    std::span<const hal::byte> transmitted;
-
-    /// @brief The portion of the buffer that was not transmitted
-    ///
-    /// The size of this buffer indicates the number of bytes unfilled
-    /// The address points to right after the `data` span. This means that
-    /// putting the `remaining` buffer back into the read() until it reaches 0
-    /// will ensure that the entire original buffer is filled to capacity.
-    std::span<const hal::byte> remaining;
+    std::span<const hal::byte> data;
   };
 
   /**

--- a/include/libhal/serial/util.hpp
+++ b/include/libhal/serial/util.hpp
@@ -43,10 +43,11 @@ namespace hal {
   serial& p_serial,
   std::span<const hal::byte> p_data_out) noexcept
 {
-  auto write_info = HAL_CHECK(p_serial.write(p_data_out));
+  auto remaining = p_data_out;
 
-  while (write_info.remaining.size() != 0) {
-    write_info = HAL_CHECK(p_serial.write(write_info.remaining));
+  while (remaining.size() != 0) {
+    auto write_length = HAL_CHECK(p_serial.write(remaining)).data.size();
+    remaining = remaining.subspan(write_length);
   }
 
   return success();
@@ -82,10 +83,11 @@ namespace hal {
   std::span<hal::byte> p_data_in,
   timeout auto p_timeout) noexcept
 {
-  auto read_result = HAL_CHECK(p_serial.read(p_data_in));
+  auto remaining = p_data_in;
 
-  while (read_result.remaining.size() != 0) {
-    read_result = HAL_CHECK(p_serial.read(read_result.remaining));
+  while (remaining.size() != 0) {
+    auto read_length = HAL_CHECK(p_serial.read(remaining)).data.size();
+    remaining = remaining.subspan(read_length);
     HAL_CHECK(p_timeout());
   }
 

--- a/tests/serial/coroutine.test.cpp
+++ b/tests/serial/coroutine.test.cpp
@@ -17,10 +17,7 @@ public:
   result<write_t> driver_write(
     std::span<const hal::byte> p_data) noexcept override
   {
-    return write_t{
-      .transmitted = p_data,
-      .remaining = std::span<const hal::byte>(),
-    };
+    return write_t{ .data = p_data };
   }
 
   result<read_t> driver_read(std::span<hal::byte> p_data) noexcept override
@@ -57,16 +54,15 @@ boost::ut::suite serial_skip_past_test = []() {
         p_data[0] = read_out[count++];
 
         return serial::read_t{
-          .received = p_data.subspan(0, 1),
-          .remaining = p_data.subspan(1),
+          .data = p_data.subspan(0, 1),
           .available = 1,
           .capacity = 1,
         };
       }
 
       return serial::read_t{
-        .received = p_data.subspan(0, 0),
-        .remaining = std::span<hal::byte>(),
+        .data = p_data.subspan(0, 0),
+
         .available = 1,
         .capacity = 1,
       };
@@ -103,16 +99,15 @@ boost::ut::suite serial_skip_past_test = []() {
           p_data[0] = read_out[count++];
 
           return serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
         }
       }
       return serial::read_t{
-        .received = p_data.subspan(0, 0),
-        .remaining = std::span<hal::byte>(),
+        .data = p_data.subspan(0, 0),
+
         .available = 1,
         .capacity = 1,
       };
@@ -149,16 +144,14 @@ boost::ut::suite serial_skip_past_test = []() {
         case 1:
           p_data[0] = read_out[count];
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
           break;
         case 2:
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 0),
-            .remaining = std::span<hal::byte>(),
+            .data = p_data.subspan(0, 0),
             .available = 1,
             .capacity = 1,
           };
@@ -166,16 +159,14 @@ boost::ut::suite serial_skip_past_test = []() {
         case 3:
           p_data[0] = read_out[count - 1];
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
           break;
         case 4:
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 0),
-            .remaining = std::span<hal::byte>(),
+            .data = p_data.subspan(0, 0),
             .available = 1,
             .capacity = 1,
           };
@@ -185,16 +176,14 @@ boost::ut::suite serial_skip_past_test = []() {
         case 7:
           p_data[0] = read_out[count - 2];
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
           break;
         default:
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 0),
-            .remaining = std::span<hal::byte>(),
+            .data = p_data.subspan(0, 0),
             .available = 1,
             .capacity = 1,
           };
@@ -231,16 +220,15 @@ boost::ut::suite serial_skip_past_test = []() {
         p_data[0] = read_out[count++];
 
         return serial::read_t{
-          .received = p_data.subspan(0, 1),
-          .remaining = p_data.subspan(1),
+          .data = p_data.subspan(0, 1),
           .available = 1,
           .capacity = 1,
         };
       }
 
       return serial::read_t{
-        .received = p_data.subspan(0, 0),
-        .remaining = std::span<hal::byte>(),
+        .data = p_data.subspan(0, 0),
+
         .available = 1,
         .capacity = 1,
       };
@@ -295,8 +283,7 @@ boost::ut::suite serial_skip_past_test = []() {
           p_data[0] = read_out[count++];
 
           return serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
@@ -359,8 +346,8 @@ boost::ut::suite serial_read_into_test = []() {
       }
 
       return serial::read_t{
-        .received = p_data,
-        .remaining = p_data.subspan(p_data.size()),
+        .data = p_data,
+
         .available = 0,
         .capacity = 1024,
       };
@@ -397,8 +384,8 @@ boost::ut::suite serial_read_into_test = []() {
       p_data[0] = static_cast<hal::byte>(counter++);
 
       return serial::read_t{
-        .received = p_data.subspan(0, 1),
-        .remaining = p_data.subspan(1),
+        .data = p_data.subspan(0, 1),
+
         .available = 1,
         .capacity = 1024,
       };
@@ -435,8 +422,8 @@ boost::ut::suite serial_read_into_test = []() {
       p_data[0] = static_cast<hal::byte>(counter++);
 
       return serial::read_t{
-        .received = p_data.subspan(0, 1),
-        .remaining = p_data.subspan(1),
+        .data = p_data.subspan(0, 1),
+
         .available = 1,
         .capacity = 1024,
       };
@@ -499,8 +486,8 @@ boost::ut::suite serial_read_upto_test = []() {
       }
 
       return serial::read_t{
-        .received = p_data,
-        .remaining = p_data.subspan(p_data.size()),
+        .data = p_data,
+
         .available = 0,
         .capacity = 1024,
       };
@@ -540,8 +527,8 @@ boost::ut::suite serial_read_upto_test = []() {
       }
 
       return serial::read_t{
-        .received = p_data,
-        .remaining = p_data.subspan(p_data.size()),
+        .data = p_data,
+
         .available = 0,
         .capacity = 1024,
       };
@@ -603,8 +590,8 @@ boost::ut::suite serial_read_upto_test = []() {
       }
 
       return serial::read_t{
-        .received = p_data,
-        .remaining = p_data.subspan(p_data.size()),
+        .data = p_data,
+
         .available = 0,
         .capacity = 1024,
       };
@@ -651,16 +638,15 @@ boost::ut::suite serial_read_uint32_test = []() {
         p_data[0] = read_out[count++];
 
         return serial::read_t{
-          .received = p_data.subspan(0, 1),
-          .remaining = p_data.subspan(1),
+          .data = p_data.subspan(0, 1),
           .available = 1,
           .capacity = 1,
         };
       }
 
       return serial::read_t{
-        .received = p_data.subspan(0, 0),
-        .remaining = std::span<hal::byte>(),
+        .data = p_data.subspan(0, 0),
+
         .available = 1,
         .capacity = 1,
       };
@@ -695,16 +681,15 @@ boost::ut::suite serial_read_uint32_test = []() {
         p_data[0] = read_out_no_ints[count++];
 
         return serial::read_t{
-          .received = p_data.subspan(0, 1),
-          .remaining = p_data.subspan(1),
+          .data = p_data.subspan(0, 1),
           .available = 1,
           .capacity = 1,
         };
       }
 
       return serial::read_t{
-        .received = p_data.subspan(0, 0),
-        .remaining = std::span<hal::byte>(),
+        .data = p_data.subspan(0, 0),
+
         .available = 1,
         .capacity = 1,
       };
@@ -742,16 +727,15 @@ boost::ut::suite serial_read_uint32_test = []() {
           p_data[0] = read_out[count++];
 
           return serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
         }
       }
       return serial::read_t{
-        .received = p_data.subspan(0, 0),
-        .remaining = std::span<hal::byte>(),
+        .data = p_data.subspan(0, 0),
+
         .available = 1,
         .capacity = 1,
       };
@@ -787,16 +771,14 @@ boost::ut::suite serial_read_uint32_test = []() {
           p_data[0] = read_out_internal_int[count++];
 
           return serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
         }
 
         return serial::read_t{
-          .received = p_data.subspan(0, 0),
-          .remaining = std::span<hal::byte>(),
+          .data = p_data.subspan(0, 0),
           .available = 1,
           .capacity = 1,
         };
@@ -834,16 +816,14 @@ boost::ut::suite serial_read_uint32_test = []() {
         case 1:
           p_data[0] = read_out[count];
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
           break;
         case 2:
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 0),
-            .remaining = std::span<hal::byte>(),
+            .data = p_data.subspan(0, 0),
             .available = 1,
             .capacity = 1,
           };
@@ -851,16 +831,14 @@ boost::ut::suite serial_read_uint32_test = []() {
         case 3:
           p_data[0] = read_out[count - 1];
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
           break;
         case 4:
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 0),
-            .remaining = std::span<hal::byte>(),
+            .data = p_data.subspan(0, 0),
             .available = 1,
             .capacity = 1,
           };
@@ -870,16 +848,14 @@ boost::ut::suite serial_read_uint32_test = []() {
         case 7:
           p_data[0] = read_out[count - 2];
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };
           break;
         default:
           read_response = serial::read_t{
-            .received = p_data.subspan(0, 0),
-            .remaining = std::span<hal::byte>(),
+            .data = p_data.subspan(0, 0),
             .available = 1,
             .capacity = 1,
           };
@@ -917,16 +893,15 @@ boost::ut::suite serial_read_uint32_test = []() {
         p_data[0] = read_out[count++];
 
         return serial::read_t{
-          .received = p_data.subspan(0, 1),
-          .remaining = p_data.subspan(1),
+          .data = p_data.subspan(0, 1),
           .available = 1,
           .capacity = 1,
         };
       }
 
       return serial::read_t{
-        .received = p_data.subspan(0, 0),
-        .remaining = std::span<hal::byte>(),
+        .data = p_data.subspan(0, 0),
+
         .available = 1,
         .capacity = 1,
       };
@@ -983,8 +958,7 @@ boost::ut::suite serial_read_uint32_test = []() {
           p_data[0] = read_out[count++];
 
           return serial::read_t{
-            .received = p_data.subspan(0, 1),
-            .remaining = p_data.subspan(1),
+            .data = p_data.subspan(0, 1),
             .available = 1,
             .capacity = 1,
           };

--- a/tests/serial/interface.test.cpp
+++ b/tests/serial/interface.test.cpp
@@ -32,7 +32,7 @@ private:
     if (m_return_error_status) {
       return hal::new_error();
     }
-    return write_t{ p_data, std::span<const hal::byte>{} };
+    return write_t{ p_data };
   };
 
   result<read_t> driver_read(std::span<hal::byte> p_data) noexcept override
@@ -41,8 +41,7 @@ private:
       return hal::new_error();
     }
     return read_t{
-      .received = p_data.subspan(0, 1),
-      .remaining = p_data.subspan(1),
+      .data = p_data.subspan(0, 1),
       .available = 1,
       .capacity = 1,
     };
@@ -81,9 +80,8 @@ boost::ut::suite serial_test = []() {
     expect(expected_settings.baud_rate == test.m_settings.baud_rate);
     expect(expected_settings.stop == test.m_settings.stop);
     expect(expected_settings.parity == test.m_settings.parity);
-    expect(that % expected_payload.data() ==
-           result2.value().transmitted.data());
-    expect(that % expected_buffer.data() == result3.value().received.data());
+    expect(that % expected_payload.data() == result2.value().data.data());
+    expect(that % expected_buffer.data() == result3.value().data.data());
     expect(true == test.m_flush_called);
   };
 

--- a/tests/serial/util.test.cpp
+++ b/tests/serial/util.test.cpp
@@ -29,17 +29,16 @@ boost::ut::suite serial_util_test = []() {
       m_out = p_data;
 
       if (single_byte_out) {
-        return write_t{ p_data.subspan(0, 1), p_data.subspan(1) };
+        return write_t{ p_data.subspan(0, 1) };
       }
-      return write_t{ p_data, std::span<const hal::byte>{} };
+      return write_t{ p_data };
     }
 
     result<read_t> driver_read(std::span<hal::byte> p_data) noexcept override
     {
       if (p_data.size() == 0) {
         return read_t{
-          .received = p_data,
-          .remaining = std::span<hal::byte>{},
+          .data = p_data,
           .available = 1,
           .capacity = 1,
         };
@@ -55,8 +54,7 @@ boost::ut::suite serial_util_test = []() {
       p_data[0] = filler_byte;
 
       return read_t{
-        .received = p_data.subspan(0, 1),
-        .remaining = p_data.subspan(1),
+        .data = p_data.subspan(0, 1),
         .available = 1,
         .capacity = 1,
       };
@@ -91,7 +89,7 @@ boost::ut::suite serial_util_test = []() {
 
       // Verify
       expect(bool{ result });
-      expect(result.value().transmitted.size() == expected_payload.size());
+      expect(result.value().data.size() == expected_payload.size());
       expect(!serial.flush_called);
       expect(that % expected_payload.data() == serial.m_out.data());
       expect(that % expected_payload.size() == serial.m_out.size());
@@ -109,7 +107,7 @@ boost::ut::suite serial_util_test = []() {
 
       // Verify
       expect(bool{ result });
-      expect(1 == result.value().transmitted.size());
+      expect(1 == result.value().data.size());
       expect(!serial.flush_called);
       expect(that % &expected_payload[0] == serial.m_out.data());
       expect(that % 4 == serial.m_out.size());


### PR DESCRIPTION
Unnecessary work for the serial driver to perform which can be performed by the caller after the fact.