### PR TITLE
Add enum socket::type

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.26"
+    version = "0.1.27"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/socket/interface.hpp
+++ b/include/libhal/socket/interface.hpp
@@ -35,6 +35,13 @@ namespace hal {
 class socket
 {
 public:
+  enum class type : hal::byte
+  {
+    tcp,
+    udp,
+    ssl
+  };
+
   /// Return data for the write operation
   struct write_t
   {


### PR DESCRIPTION
socket::type represents the socket type as being tcp, udp or ssl. This can be used by socket fatory functions to establish the socket type.