### PR TITLE
Fix boost leaf macro issues in tweaks file

### DIFF
--- a/include/libhal/error.hpp
+++ b/include/libhal/error.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+// "config.hpp" MUST be included before <boost/leaf.hpp> is included to ensure
+// that the libahl.tweaks.hpp file is evaluated first and that any macro
+// definitions for boost leaf are defined before including boost, otherwise,
+// they will be ignored.
+#include "config.hpp"
+
 #include <boost/leaf.hpp>
 #include <system_error>
-
-#include "config.hpp"
 
 #define HAL_CHECK BOOST_LEAF_CHECK
 


### PR DESCRIPTION
The `error.hpp` file is main include that brings in Boost.LEAF as well as the libhal.tweaks file via the config include. The position of the config include is below Boost.LEAF which results in the macro definitions being ignored. Moving the "config.hpp" to the top of the file will change this.

Resolves #561