### PR TITLE
hal::bit non-template variants

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.29"
+    version = "0.1.30"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
 set(CMAKE_BUILD_TYPE "Debug")
 
 find_package(ut REQUIRED CONFIG)
-find_package(libhal REQUIRED CONFIG)
+find_package(boost-leaf REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME}
   can/interface.test.cpp
@@ -90,4 +90,4 @@ target_compile_options(${PROJECT_NAME} PRIVATE -Werror -Wall -Wextra
   -Wno-unused-function -Wconversion -Wno-psabi)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
-target_link_libraries(${PROJECT_NAME} PRIVATE Boost::ut libhal::libhal)
+target_link_libraries(${PROJECT_NAME} PRIVATE Boost::ut boost::leaf)

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
+boost-leaf/[>=1.80.0, include_prerelease=True]
 boost-ext-ut/1.1.9
-libhal/[>=0.0.0]
 
 [generators]
 CMakeToolchain


### PR DESCRIPTION
- Bump version to 0.1.30
- Add `static constexpr` to templated functions to take advantage of compile time computation
- Remove libhal package from unit tests