### PR TITLE
Improve non-template bit library

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.30"
+    version = "0.1.31"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/bit.hpp
+++ b/include/libhal/bit.hpp
@@ -36,6 +36,23 @@ struct mask
     return mask{ .position = position, .width = 1U };
   }
 
+  static consteval mask from(std::uint32_t position1, std::uint32_t position2)
+  {
+    constexpr std::uint32_t plus_one = 1;
+    if (position1 < position2) {
+      return mask{ .position = position1,
+                   .width = plus_one + (position2 - position1) };
+    } else {
+      return mask{ .position = position2,
+                   .width = plus_one + (position1 - position2) };
+    }
+  }
+
+  static constexpr mask from(std::uint32_t position)
+  {
+    return mask{ .position = position, .width = 1U };
+  }
+
   template<std::unsigned_integral T>
   constexpr auto origin_mask() const
   {
@@ -113,8 +130,6 @@ public:
 
   constexpr auto& set(mask p_field)
   {
-    static_assert(p_field.position < width,
-                  "Bit position exceeds register width");
     const auto mask = static_cast<T>(1U << p_field.position);
 
     m_value = m_value | mask;
@@ -137,8 +152,6 @@ public:
 
   constexpr auto& clear(mask p_field)
   {
-    static_assert(p_field.position < width,
-                  "Bit position exceeds register width");
     const auto mask = static_cast<T>(1U << p_field.position);
     const auto inverted_mask = ~mask;
 
@@ -162,9 +175,6 @@ public:
 
   constexpr auto& toggle(mask p_field)
   {
-    static_assert(p_field.position < width,
-                  "Bit position exceeds register width");
-
     const auto mask = static_cast<T>(1U << p_field.position);
 
     m_value = m_value ^ mask;

--- a/include/libhal/interrupt_pin/interface.hpp
+++ b/include/libhal/interrupt_pin/interface.hpp
@@ -64,8 +64,8 @@ public:
 
   /// Interrupt pin handler
   ///
-  /// @param true - state of the pin when the interrupt was triggered was HIGH
-  /// @param false - state of the pin when the interrupt was triggered was LOW
+  /// param p_state - if true state of the pin when the interrupt was triggered
+  /// was HIGH, otherwise LOW
   using handler = void(bool p_state);
 
   /**

--- a/tests/bit.test.cpp
+++ b/tests/bit.test.cpp
@@ -6,7 +6,7 @@ namespace hal {
 boost::ut::suite bit_test = []() {
   using namespace boost::ut;
 
-  "hal::bit standard usage"_test = []() {
+  "hal::bit<template> standard usage"_test = []() {
     // Setup
     volatile std::uint32_t control_register = 1 << 15 | 1 << 16;
     constexpr auto enable_bit = bit::mask::from<1>();
@@ -24,6 +24,32 @@ boost::ut::suite bit_test = []() {
     auto probed = bit::extract<single_bit_mask>(control_register);
     auto probed_inline =
       bit::extract<bit::mask{ .position = 15, .width = 1 }>(control_register);
+
+    // Verify
+    expect(that % 0x00A1'0002 == control_register);
+    expect(that % 0xA1 == extracted);
+    expect(that % 1 == probed);
+    expect(that % 0 == probed_inline);
+  };
+
+  "hal::bit standard usage "_test = []() {
+    // Setup
+    volatile std::uint32_t control_register = 1 << 15 | 1 << 16;
+    constexpr auto enable_bit = bit::mask::from<1>();
+    constexpr auto high_power_mode = bit::mask::from<15>();
+    constexpr auto clock_divider = bit::mask::from<20, 23>();
+    constexpr auto extractor_mask = bit::mask::from<16, 23>();
+    constexpr auto single_bit_mask = bit::mask::from<1>();
+
+    // Exercise
+    bit::modify(control_register)
+      .set(enable_bit)
+      .clear(high_power_mode)
+      .insert(clock_divider, 0xAU);
+    auto extracted = bit::extract(extractor_mask, control_register);
+    auto probed = bit::extract(single_bit_mask, control_register);
+    auto probed_inline =
+      bit::extract(bit::mask{ .position = 15, .width = 1 }, control_register);
 
     // Verify
     expect(that % 0x00A1'0002 == control_register);


### PR DESCRIPTION
- Add runtime mask::from functions
- Remove incorrect static_asserts on runtime mask objects
- Add unit tests for runtime bit libraries