### PR TITLE
Add timeout to socket write

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.32"
+    version = "0.1.33"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/tests/socket/interface.test.cpp
+++ b/tests/socket/interface.test.cpp
@@ -1,6 +1,7 @@
 #include <libhal/socket/interface.hpp>
 
 #include <boost/ut.hpp>
+#include <libhal/callback_recorder.hpp>
 #include <libhal/testing.hpp>
 
 namespace hal {
@@ -18,12 +19,15 @@ public:
   }
 
 private:
-  hal::result<write_t> driver_write(std::span<const hal::byte> p_data) noexcept
+  hal::result<write_t> driver_write(
+    std::span<const hal::byte> p_data,
+    std::function<hal::timeout_function> p_timeout) noexcept
   {
     if (m_return_error_status) {
       return new_error();
     }
     m_write = p_data;
+    (void)p_timeout();
     return write_t{ p_data.first(2) };
   }
   hal::result<read_t> driver_read(std::span<hal::byte> p_data) noexcept
@@ -43,9 +47,13 @@ boost::ut::suite socket_test = []() {
     // Setup
     test_socket test;
     std::array<hal::byte, 4> buffer;
+    std::function<timeout_function> always_succeed = []() -> hal::status {
+      return hal::success();
+    };
+    hal::mock::callback_recorder<timeout_function> recorder(always_succeed);
 
     // Exercise
-    auto write_result = test.write(buffer);
+    auto write_result = test.write(buffer, recorder.callback());
     auto read_result = test.read(buffer);
 
     // Verify
@@ -59,6 +67,7 @@ boost::ut::suite socket_test = []() {
     expect(that % write_result.value().data.size() == 2);
     expect(that % read_result.value().data.data() == test.m_read.data());
     expect(that % read_result.value().data.size() == 2);
+    expect(that % true == recorder.was_called_once());
   };
 
   "socket errors test"_test = []() {
@@ -66,14 +75,19 @@ boost::ut::suite socket_test = []() {
     test_socket test;
     test.m_return_error_status = true;
     std::array<hal::byte, 4> buffer;
+    std::function<timeout_function> always_succeed = []() -> hal::status {
+      return hal::success();
+    };
+    hal::mock::callback_recorder<timeout_function> recorder(always_succeed);
 
     // Exercise
-    auto write_result = test.write(buffer);
+    auto write_result = test.write(buffer, recorder.callback());
     auto read_result = test.read(buffer);
 
     // Verify
     expect(!bool{ write_result });
     expect(!bool{ read_result });
+    expect(that % false == recorder.was_called_once());
   };
 };
 }  // namespace hal


### PR DESCRIPTION
Socket write operations on syncronous sockets could take a considerable amount of time due to network latency. Because of this, a timeout can be used to bail out of the function if it takes too long.