### PR TITLE
Remove C style arrays from hal::as_bytes

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.1.33"
+    version = "0.1.34"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/as_bytes.hpp
+++ b/include/libhal/as_bytes.hpp
@@ -40,10 +40,4 @@ constexpr std::span<const hal::byte> as_bytes(
 {
   return as_bytes(p_container.data(), p_container.size());
 }
-
-template<typename T, std::size_t N>
-constexpr std::span<const hal::byte> as_bytes(const T (&array)[N])
-{
-  return as_bytes(array, N);
-}
 }  // namespace hal

--- a/tests/as_bytes.test.cpp
+++ b/tests/as_bytes.test.cpp
@@ -114,29 +114,6 @@ boost::ut::suite as_bytes_test = []() {
         expect(that % array_pointer == actual.data());
         expect(that % array_byte_size == actual.size());
       }
-      {
-        // Exercise
-        auto actual = hal::as_bytes("Hello World");
-        // Verify
-        // Verify: this works because almost all compilers will find common
-        // strings and place them in the same location, therefor, the location
-        // of a string "Hello World" will always be the same.
-        expect(that % reinterpret_cast<const hal::byte*>("Hello World") ==
-               actual.data());
-        expect(that % sizeof("Hello World") == actual.size());
-      }
-      {
-        int c_int_array[] = { 1, 2, 3, 5 };
-        // Exercise
-        auto actual = hal::as_bytes(c_int_array);
-        // Verify
-        // Verify: this works because almost all compilers will find common
-        // strings and place them in the same location, therefor, the location
-        // of a string "Hello World" will always be the same.
-        expect(that % reinterpret_cast<const hal::byte*>(c_int_array) ==
-               actual.data());
-        expect(that % sizeof(c_int_array) == actual.size());
-      }
     };
   };
 };


### PR DESCRIPTION
- C style arrays should be discouraged in the code base
- Critical issues come from string literals which include a null character which get included in the span range, which can be an issue in many applications