### PR TITLE
:children_crossing: Add apt ubuntu toolchain step to prerequisites

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -20,8 +20,8 @@ Python 3.10 is default installed.
 Install GCC and build essentials.
 
 ```
-sudo apt update
-sudo apt upgrade
+sudo apt update && sudo apt upgrade
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt install -y build-essential g++-11
 ```
 


### PR DESCRIPTION
Will allow users to install g++-11 on older versions of Ubuntu.