### PR TITLE
:green_heart: Fix incorrect library name for deploy

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -94,5 +94,5 @@ jobs:
     needs: [ lint, docs, tests ]
     uses: ./.github/workflows/deploy.yml
     with:
-      library: libhal
+      library: ${{ inputs.library }}
     secrets: inherit


### PR DESCRIPTION
Was hard coded to "libhal" when it should be `${{ inputs.library }}`