### PR TITLE
:heavy_plus_sign: Add & use tl::function_ref in all APIs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.3.0"
+    version = "0.3.1"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"
@@ -57,6 +57,9 @@ class LibHALConan(ConanFile):
 
     def layout(self):
         basic_layout(self)
+
+    def requirements(self):
+        self.requires("tl-function-ref/1.0.0")
 
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(

--- a/include/libhal/adc.hpp
+++ b/include/libhal/adc.hpp
@@ -6,7 +6,6 @@
 #include "error.hpp"
 
 namespace hal {
-
 /**
  * @brief Analog to Digital Converter (ADC) hardware abstraction interface.
  *

--- a/include/libhal/alias.hpp
+++ b/include/libhal/alias.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "config.hpp"
+
+#include <tl/function_ref.hpp>
+
+namespace hal {
+template<typename F>
+using function_ref = tl::function_ref<F>;
+}  // namespace hal

--- a/include/libhal/can.hpp
+++ b/include/libhal/can.hpp
@@ -2,13 +2,12 @@
 
 #include <array>
 #include <cstdint>
-#include <functional>
 
+#include "alias.hpp"
 #include "error.hpp"
 #include "units.hpp"
 
 namespace hal {
-
 /**
  * @brief Controller Area Network (CAN bus) hardware abstraction interface.
  *
@@ -118,7 +117,7 @@ public:
    * received. Set to "nullptr" to disable receive interrupts.
    * @return status - success or failure
    */
-  [[nodiscard]] status on_receive(std::function<handler> p_handler)
+  [[nodiscard]] status on_receive(hal::function_ref<handler> p_handler)
   {
     return driver_on_receive(p_handler);
   }
@@ -128,6 +127,6 @@ public:
 private:
   virtual status driver_configure(const settings& p_settings) = 0;
   virtual status driver_send(const message_t& p_message) = 0;
-  virtual status driver_on_receive(std::function<handler> p_handler) = 0;
+  virtual status driver_on_receive(hal::function_ref<handler> p_handler) = 0;
 };
 }  // namespace hal

--- a/include/libhal/i2c.hpp
+++ b/include/libhal/i2c.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <functional>
 #include <span>
 
+#include "alias.hpp"
 #include "error.hpp"
 #include "timeout.hpp"
 #include "units.hpp"
@@ -95,7 +95,7 @@ public:
     hal::byte p_address,
     std::span<const hal::byte> p_data_out,
     std::span<hal::byte> p_data_in,
-    std::function<hal::timeout_function> p_timeout)
+    hal::function_ref<hal::timeout_function> p_timeout)
   {
     return driver_transaction(p_address, p_data_out, p_data_in, p_timeout);
   }
@@ -108,6 +108,6 @@ private:
     hal::byte p_address,
     std::span<const hal::byte> p_data_out,
     std::span<hal::byte> p_data_in,
-    std::function<hal::timeout_function> p_timeout) = 0;
+    hal::function_ref<hal::timeout_function> p_timeout) = 0;
 };
 }  // namespace hal

--- a/include/libhal/interrupt_pin.hpp
+++ b/include/libhal/interrupt_pin.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <functional>
-
+#include "alias.hpp"
 #include "error.hpp"
 #include "units.hpp"
 
@@ -75,7 +74,7 @@ public:
    * @param p_callback function to execute when the trigger condition is met.
    * Set to nullptr to disable this interrupt.
    */
-  void on_trigger(std::function<handler> p_callback)
+  void on_trigger(hal::function_ref<handler> p_callback)
   {
     return driver_on_trigger(p_callback);
   }
@@ -84,6 +83,6 @@ public:
 
 private:
   virtual status driver_configure(const settings& p_settings) = 0;
-  virtual void driver_on_trigger(std::function<handler> p_callback) = 0;
+  virtual void driver_on_trigger(hal::function_ref<handler> p_callback) = 0;
 };
 }  // namespace hal

--- a/include/libhal/socket.hpp
+++ b/include/libhal/socket.hpp
@@ -2,6 +2,7 @@
 
 #include <span>
 
+#include "alias.hpp"
 #include "error.hpp"
 #include "timeout.hpp"
 #include "units.hpp"
@@ -67,7 +68,7 @@ public:
    */
   [[nodiscard]] hal::result<write_t> write(
     std::span<const hal::byte> p_data,
-    std::function<hal::timeout_function> p_timeout)
+    hal::function_ref<hal::timeout_function> p_timeout)
   {
     return driver_write(p_data, p_timeout);
   }
@@ -102,7 +103,7 @@ public:
 private:
   virtual hal::result<write_t> driver_write(
     std::span<const hal::byte> p_data,
-    std::function<hal::timeout_function> p_timeout) = 0;
+    hal::function_ref<hal::timeout_function> p_timeout) = 0;
   virtual hal::result<read_t> driver_read(std::span<hal::byte> p_data) = 0;
 };
 }  // namespace hal

--- a/include/libhal/timeout.hpp
+++ b/include/libhal/timeout.hpp
@@ -6,8 +6,7 @@
  */
 #pragma once
 
-#include <functional>
-
+#include "alias.hpp"
 #include "error.hpp"
 
 namespace hal {
@@ -38,7 +37,7 @@ enum class work_state
 using timeout_function = status(void);
 
 template<class T>
-concept timeout = std::convertible_to<T, std::function<timeout_function>>;
+concept timeout = std::convertible_to<T, hal::function_ref<timeout_function>>;
 
 /**
  * @brief A non-blocking callable that performs work with each call
@@ -59,7 +58,7 @@ concept timeout = std::convertible_to<T, std::function<timeout_function>>;
 using work_function = result<work_state>();
 
 template<class T>
-concept worker = std::convertible_to<T, std::function<work_function>>;
+concept worker = std::convertible_to<T, hal::function_ref<work_function>>;
 
 /**
  * @brief Delay the execution of the application or thread for a duration of

--- a/include/libhal/timer.hpp
+++ b/include/libhal/timer.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <chrono>
-#include <functional>
 
+#include "alias.hpp"
 #include "error.hpp"
 #include "units.hpp"
 
@@ -86,7 +86,7 @@ public:
    * @throws out_of_bounds - if p_interval is greater than what can be cannot be
    * achieved
    */
-  [[nodiscard]] status schedule(std::function<void(void)> p_callback,
+  [[nodiscard]] status schedule(hal::function_ref<void(void)> p_callback,
                                 hal::time_duration p_delay)
   {
     return driver_schedule(p_callback, p_delay);
@@ -97,7 +97,7 @@ public:
 private:
   virtual result<bool> driver_is_running() = 0;
   virtual status driver_cancel() = 0;
-  virtual status driver_schedule(std::function<void(void)> p_callback,
+  virtual status driver_schedule(hal::function_ref<void(void)> p_callback,
                                  hal::time_duration p_delay) = 0;
 };
 }  // namespace hal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
 set(CMAKE_BUILD_TYPE "Debug")
 
 find_package(ut REQUIRED CONFIG)
+find_package(tl-function-ref REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME}
   can.test.cpp
@@ -64,4 +65,4 @@ target_link_options(${PROJECT_NAME} PRIVATE
   --coverage
   -fprofile-arcs
   -ftest-coverage)
-target_link_libraries(${PROJECT_NAME} PRIVATE Boost::ut)
+target_link_libraries(${PROJECT_NAME} PRIVATE Boost::ut tl::function-ref)

--- a/tests/can.test.cpp
+++ b/tests/can.test.cpp
@@ -1,5 +1,7 @@
 #include <libhal/can.hpp>
 
+#include <functional>
+
 #include <boost/ut.hpp>
 
 namespace hal {
@@ -9,17 +11,15 @@ constexpr hal::can::settings expected_settings{
 };
 int counter = 0;
 constexpr hal::can::message_t expected_message{ .id = 1, .length = 0 };
-const std::function<hal::can::handler> expected_handler =
-  [](hal::can::message_t p_expected_message) {
-    counter++;
-    return p_expected_message;
-  };
+hal::function_ref<hal::can::handler> expected_handler =
+  [](const hal::can::message_t&) { counter++; };
+
 class test_can : public hal::can
 {
 public:
   settings m_settings{};
   message_t m_message{};
-  std::function<handler> m_handler{};
+  std::function<handler> m_handler = [](const message_t&) {};
   bool m_return_error_status{ false };
 
 private:
@@ -41,7 +41,7 @@ private:
     return success();
   };
 
-  status driver_on_receive(std::function<handler> p_handler) override
+  status driver_on_receive(hal::function_ref<handler> p_handler) override
   {
     m_handler = p_handler;
     if (m_return_error_status) {

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
 boost-ext-ut/1.1.9
+tl-function-ref/1.0.0
 
 [generators]
 CMakeToolchain

--- a/tests/i2c.test.cpp
+++ b/tests/i2c.test.cpp
@@ -1,5 +1,7 @@
 #include <libhal/i2c.hpp>
 
+#include <functional>
+
 #include <boost/ut.hpp>
 
 namespace hal {
@@ -8,7 +10,7 @@ constexpr hal::i2c::settings expected_settings{ .clock_rate = 1.0_Hz };
 constexpr hal::byte expected_address{ 100 };
 constexpr std::array<hal::byte, 4> expected_data_out{ 'a', 'b' };
 std::array<hal::byte, 4> expected_data_in{ '1', '2' };
-const std::function<hal::timeout_function> expected_timeout = []() {
+const hal::function_ref<hal::timeout_function> expected_timeout = []() {
   return success();
 };
 
@@ -19,7 +21,9 @@ public:
   hal::byte m_address{};
   std::span<const hal::byte> m_data_out{};
   std::span<hal::byte> m_data_in{};
-  std::function<hal::timeout_function> m_timeout{};
+  std::function<hal::timeout_function> m_timeout = []() -> hal::status {
+    return hal::success();
+  };
   bool m_return_error_status{ false };
 
 private:
@@ -35,7 +39,7 @@ private:
     hal::byte p_address,
     std::span<const hal::byte> p_data_out,
     std::span<hal::byte> p_data_in,
-    std::function<hal::timeout_function> p_timeout) override
+    hal::function_ref<hal::timeout_function> p_timeout) override
   {
     HAL_CHECK(p_timeout());
     m_address = p_address;

--- a/tests/interrupt_pin.test.cpp
+++ b/tests/interrupt_pin.test.cpp
@@ -1,5 +1,7 @@
 #include <libhal/interrupt_pin.hpp>
 
+#include <functional>
+
 #include <boost/ut.hpp>
 
 namespace hal {
@@ -13,7 +15,7 @@ class test_interrupt_pin : public hal::interrupt_pin
 {
 public:
   settings m_settings{};
-  std::function<handler> m_callback{};
+  std::function<handler> m_callback = [](bool) {};
   bool m_return_error_status{ false };
 
 private:
@@ -25,7 +27,7 @@ private:
     }
     return success();
   };
-  void driver_on_trigger(std::function<handler> p_callback) override
+  void driver_on_trigger(hal::function_ref<handler> p_callback) override
   {
     m_callback = p_callback;
   };
@@ -39,7 +41,7 @@ void interrupt_pin_test()
     // Setup
     test_interrupt_pin test;
     int counter = 0;
-    const std::function<void(bool)> expected_callback = [&counter](bool) {
+    const hal::function_ref<void(bool)> expected_callback = [&counter](bool) {
       counter++;
     };
 

--- a/tests/socket.test.cpp
+++ b/tests/socket.test.cpp
@@ -19,7 +19,7 @@ public:
 private:
   hal::result<write_t> driver_write(
     std::span<const hal::byte> p_data,
-    std::function<hal::timeout_function> p_timeout)
+    hal::function_ref<hal::timeout_function> p_timeout)
   {
     if (m_return_error_status) {
       return new_error();
@@ -42,7 +42,7 @@ private:
 void socket_test()
 {
   using namespace boost::ut;
-  std::function<timeout_function> always_succeed = []() -> hal::status {
+  hal::function_ref<timeout_function> always_succeed = []() -> hal::status {
     return hal::success();
   };
 

--- a/tests/timer.test.cpp
+++ b/tests/timer.test.cpp
@@ -1,5 +1,7 @@
 #include <libhal/timer.hpp>
 
+#include <functional>
+
 #include <boost/ut.hpp>
 
 namespace hal {
@@ -8,7 +10,7 @@ class test_timer : public hal::timer
 {
 public:
   bool m_is_running{ false };
-  std::function<void(void)> m_callback{};
+  std::function<void(void)> m_callback = []() {};
   hal::time_duration m_delay;
   bool m_return_error_status{ false };
 
@@ -28,7 +30,7 @@ private:
     }
     return success();
   };
-  status driver_schedule(std::function<void(void)> p_callback,
+  status driver_schedule(hal::function_ref<void(void)> p_callback,
                          hal::time_duration p_delay) override
   {
     m_is_running = true;
@@ -48,7 +50,7 @@ void timer_test()
   "timer interface test"_test = []() {
     // Setup
     test_timer test;
-    const std::function<void(void)> expected_callback = []() {};
+    const hal::function_ref<void(void)> expected_callback = []() {};
     const std::chrono::nanoseconds expected_delay = {};
 
     // Exercise + Verify
@@ -61,7 +63,6 @@ void timer_test()
     expect(bool{ result1 });
     expect(bool{ result2 });
     expect(that % true == result1.value());
-    expect(bool{ test.m_callback });
     expect(expected_delay == test.m_delay);
 
     auto result3 = test.cancel();
@@ -73,7 +74,7 @@ void timer_test()
   "timer errors test"_test = []() {
     // Setup
     test_timer test;
-    const std::function<void(void)> expected_callback = []() {};
+    const hal::function_ref<void(void)> expected_callback = []() {};
     const std::chrono::nanoseconds expected_delay = {};
     test.m_return_error_status = true;
 


### PR DESCRIPTION
tl::function_ref is an implementation of the future std::function_ref. When std::function_ref is released, `hal::function_ref` will point to it instead of `tl::function_ref`.

Migrate from `std::function` to `hal::function_ref` because the former is owning, potentially allocating, and results in copies, where as the later is non-owning, never allocates and is the size of just two pointers.

Bump version to 0.3.1