### PR TITLE
:zap: `can::on_receive()` now returns void

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.3.3"
+    version = "0.3.4"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/can.hpp
+++ b/include/libhal/can.hpp
@@ -115,9 +115,8 @@ public:
    *
    * @param p_handler - this handler will be called when a message has been
    * received.
-   * @return status - success or failure
    */
-  [[nodiscard]] status on_receive(hal::callback<handler> p_handler)
+  void on_receive(hal::callback<handler> p_handler)
   {
     return driver_on_receive(p_handler);
   }
@@ -127,6 +126,6 @@ public:
 private:
   virtual status driver_configure(const settings& p_settings) = 0;
   virtual status driver_send(const message_t& p_message) = 0;
-  virtual status driver_on_receive(hal::callback<handler> p_handler) = 0;
+  virtual void driver_on_receive(hal::callback<handler> p_handler) = 0;
 };
 }  // namespace hal

--- a/tests/can.test.cpp
+++ b/tests/can.test.cpp
@@ -41,13 +41,9 @@ private:
     return success();
   };
 
-  status driver_on_receive(hal::callback<handler> p_handler) override
+  void driver_on_receive(hal::callback<handler> p_handler) override
   {
     m_handler = p_handler;
-    if (m_return_error_status) {
-      return hal::new_error();
-    }
-    return success();
   };
 };
 }  // namespace
@@ -63,13 +59,12 @@ void can_test()
     // Exercise
     auto result1 = test.configure(expected_settings);
     auto result2 = test.send(expected_message);
-    auto result3 = test.on_receive(expected_handler);
+    test.on_receive(expected_handler);
     test.m_handler(expected_message);
 
     // Verify
     expect(bool{ result1 });
     expect(bool{ result2 });
-    expect(bool{ result3 });
     expect(that % expected_settings.baud_rate == test.m_settings.baud_rate);
     expect(that % expected_message.id == test.m_message.id);
     expect(that % 1 == counter);
@@ -83,12 +78,10 @@ void can_test()
     // Exercise
     auto result1 = test.configure(expected_settings);
     auto result2 = test.send(expected_message);
-    auto result3 = test.on_receive(expected_handler);
 
     // Verify
     expect(!bool{ result1 });
     expect(!bool{ result2 });
-    expect(!bool{ result3 });
   };
 };
 }  // namespace hal


### PR DESCRIPTION
See A.20