### PR TITLE
:zap: Improve `pwm` interface performance & docs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "0.3.4"
+    version = "0.3.5"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/pwm.hpp
+++ b/include/libhal/pwm.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 
 #include "config.hpp"
@@ -56,12 +57,28 @@ public:
   /**
    * @brief Set the pwm waveform duty cycle
    *
-   * @param p_duty_cycle - set the duty cycle of the pwm
+   * The input value `p_duty_cycle` is a 32-bit floating point value from 0.0f
+   * to 1.0f.
+   *
+   * The floating point value is directly proportional to the duty cycle
+   * percentage, such that 0.0 is 0%, 0.25 is 25%, 0.445 is 44.5% and 1.0 is
+   * 100%.
+   *
+   * This function clamps the input value between 0.0f and 1.0f and thus  values
+   * passed to driver implementations are guaranteed to be within this range.
+   * Callers of this function do not need to clamp their values before passing
+   * them into this function as it would be redundant. The rationale for doing
+   * this at the interface layer is that it allows callers and driver
+   * implementors to omit redundant clamping code and thus reducing code bloat.
+   *
+   * @param p_duty_cycle - a value from 0.0 to 1.0 representing the duty cycle
+   * percentage.
    * @return status - success or failure
    */
   [[nodiscard]] status duty_cycle(float p_duty_cycle)
   {
-    return driver_duty_cycle(p_duty_cycle);
+    auto clamped_duty_cycle = std::clamp(p_duty_cycle, 0.0f, 1.0f);
+    return driver_duty_cycle(clamped_duty_cycle);
   }
 
   virtual ~pwm() = default;


### PR DESCRIPTION
`hal::pwm` now has a full explanation regarding what are the possible input values `pwm::duty_cycle` can take. The performance boost comes from putting the clamp function into the interface, the first of such situations in libhal, in order to create a guarantee about the value passed to the driver. This guarantee allows callers and implementors to eliminate checks and clamping code and manage all of this in one central place, reducing code bloat.