### PR TITLE
:zap: Improve `pwm` interface performance & docs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "1.0.0"
+    version = "1.0.1"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/pwm.hpp
+++ b/include/libhal/pwm.hpp
@@ -62,6 +62,13 @@ public:
   /**
    * @brief Set the pwm waveform frequency
    *
+   * This function clamps the input value between 1.0_Hz and 1.0_GHz and thus
+   * values passed to driver implementations are guaranteed to be within this
+   * range. Callers of this function do not need to clamp their values before
+   * passing them into this function as it would be redundant. The rationale for
+   * doing this at the interface layer is that it allows callers and driver
+   * implementors to omit redundant clamping code, reducing code bloat.
+   *
    * @param p_frequency - settings to apply to pwm driver
    * @return result<frequency_t> - success or failure
    * @throws std::errc::argument_out_of_domain - if the frequency is beyond what
@@ -69,7 +76,8 @@ public:
    */
   [[nodiscard]] result<frequency_t> frequency(hertz p_frequency)
   {
-    return driver_frequency(p_frequency);
+    auto clamped_frequency = std::clamp(p_frequency, 1.0_Hz, 1.0_GHz);
+    return driver_frequency(clamped_frequency);
   }
 
   /**


### PR DESCRIPTION
Added clamp function to pwm::frequency to clamp values between 1 Hz and 1 GHz. This allows callers and implementors to eliminate checks and clamping code by keeping them in a central place, which helps reduce code bloat.