### PR TITLE
:green_heart: Set conan version to 1.57.0 in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 0
 
       - name: 📥 Install CMake + Conan + GCovr
-        run: pip3 install --upgrade cmake conan gcovr
+        run: pip3 install --upgrade cmake conan==1.57.0 gcovr
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: conan remote add libhal-trunk


### PR DESCRIPTION
Demos break when using the current latest version of 1.59.0 because the CMAKE_PROGRAM_PATH variables in conan_toolchain.cmake are not correctly set.