### PR TITLE
:green_heart: Fix test.yml & lock conan version to 1.57.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
           - os: macos-12
           - os: windows-2022
     runs-on: ${{ matrix.os }}
-    environment: Production
     steps:
       - uses: actions/checkout@v2
         with:
@@ -45,10 +44,7 @@ jobs:
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: conan remote add libhal-trunk
-             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan --insert
-
-      - name: 📡 Enable conan revision mode
-        run: conan config set general.revisions_enabled=True
+             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Create and setup default profile
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,15 +21,23 @@ jobs:
         run: sudo apt install g++-11 build-essential
 
       - name: 📥 Install CMake & Conan
-        run: pip install cmake conan
+        run: pip install cmake conan==1.57.0
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: |
              conan remote add libhal-trunk \
-             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan --insert
+             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
-      - name: 📡 Enable conan revision mode
-        run: conan config set general.revisions_enabled=True
+      - name: 📡 Create and setup default profile
+        run: |
+            conan profile new default --detect
+            conan profile update settings.build_type=Debug default
+            conan profile update settings.compiler.libcxx=libstdc++ default
+            conan profile update settings.compiler=gcc default
+            conan profile update settings.compiler.version=11 default
+
+      - name: 👁️‍🗨️ Show conan profile
+        run: conan profile show default
 
       - name: 📦 Create Conan Package & Verify Test Package
         run: conan create . --test-folder test_package

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-22.04
-    environment: Production
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-22.04
-    environment: Production
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,6 @@ jobs:
           #   enable_latest_version_badge: false
 
     runs-on: ${{ matrix.os }}
-    environment: Production
     steps:
       - uses: actions/checkout@v2
         with:
@@ -56,11 +55,11 @@ jobs:
         run: sudo apt install ${{ matrix.install_name }}
 
       - name: 📥 Install CMake + Conan + GCovr
-        run: pip3 install --upgrade cmake conan gcovr
+        run: pip3 install --upgrade cmake conan==1.57.0 gcovr
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: conan remote add libhal-trunk
-             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan --insert
+             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Enable conan revision mode
         run: conan config set general.revisions_enabled=True
@@ -151,7 +150,6 @@ jobs:
             install_name:
 
     runs-on: ${{ matrix.os }}
-    environment: Production
     steps:
       - uses: actions/checkout@v2
         with:
@@ -163,11 +161,11 @@ jobs:
         run: brew install ${{ matrix.install_name }}
 
       - name: 📥 Install CMake + Conan + GCovr
-        run: pip3 install --upgrade cmake conan gcovr
+        run: pip3 install --upgrade cmake conan==1.57.0 gcovr
 
       - name: 📡 Add `libhal-trunk` conan remote
         run: conan remote add libhal-trunk
-             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan --insert
+             https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
 
       - name: 📡 Enable conan revision mode
         run: conan config set general.revisions_enabled=True
@@ -182,6 +180,9 @@ jobs:
               settings.compiler=${{ matrix.toolchain }} default
             conan profile update \
               settings.compiler.version=${{ matrix.compiler_version }} default
+
+      - name: 👁️‍🗨️ Show conan profile
+        run: conan profile show default
 
       - name: 📦 Generate Package & Install Library
         run: conan create . --test-folder test_package


### PR DESCRIPTION
conan 2.0.0 breaks our CI as it doesn't have the `--insert` argument for `conan remote add`