### PR TITLE
:sparkles: Add `hal::servo` interface

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibHALConan(ConanFile):
     name = "libhal"
-    version = "1.0.1"
+    version = "1.1.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"

--- a/include/libhal/motor.hpp
+++ b/include/libhal/motor.hpp
@@ -5,7 +5,7 @@
 
 namespace hal {
 /**
- * @brief Open loop motorized actuator hardware abstraction
+ * @brief Hardware abstraction for an open loop rotational actuator
  *
  * The motor interface can represent a variety of things such as:
  *

--- a/include/libhal/servo.hpp
+++ b/include/libhal/servo.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "config.hpp"
+#include "error.hpp"
+#include "units.hpp"
+
+namespace hal {
+/**
+ * @brief Hardware abstraction for a closed loop position controlled rotational
+ * actuator
+ *
+ */
+class servo
+{
+public:
+  /**
+   * @brief Feedback from setting the servo position
+   *
+   * This structure is currently empty as no feedback has been determined for
+   * now. This structure may be expanded in the future.
+   */
+  struct position_t
+  {};
+
+  /**
+   * @brief Error information indicating the range of the servo
+   *
+   */
+  struct range_error
+  {
+    /**
+     * @brief Minimum range of the servo shaft in degrees
+     *
+     */
+    hal::degrees min;
+    /**
+     * @brief Maximum range of the servo shaft in degrees
+     *
+     */
+    hal::degrees max;
+  };
+
+  /**
+   * @brief Set the position of the servo's output shaft
+   *
+   * Position is the rotational position as a angle in degrees that the caller
+   * wants the shaft to rotate to. The allowed range of positions is defined by
+   * the servo itself. Many servos have intrinsic limits to their range.
+   *
+   * Developers must choose servos that fit the range for their applications.
+   * Applications must clearly define the range that they require in order to
+   * perform correctly.
+   *
+   * The velocity in which the servo shaft moves is not defined by this function
+   * but is either intrinsic to the servo or a configuration of the servo.
+   *
+   * @param p_position - the position to move the servo shaft in degrees.
+   * @return result<position_t> - success or failure
+   * @throws std::errc::invalid_argument - when position exceeds the range of
+   * the servo. When this error occurs, the guaranteed behavior is that the
+   * servo keeps its last set position.
+   * @throws hal::servo::range_error - when position exceeds the range of
+   * the servo. Provides details about the min and max range of the servo. When
+   * this error occurs, the guaranteed behavior is that the servo keeps its last
+   * set position.
+   */
+  [[nodiscard]] result<position_t> position(hal::degrees p_position)
+  {
+    return driver_position(p_position);
+  }
+
+  virtual ~servo() = default;
+
+private:
+  virtual result<position_t> driver_position(hal::degrees p_power) = 0;
+};
+}  // namespace hal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(${PROJECT_NAME}
   magnetometer.test.cpp
   rotation_sensor.test.cpp
   temperature_sensor.test.cpp
+  servo.test.cpp
   main.test.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC . ../include)

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -17,6 +17,7 @@ extern void spi_test();
 extern void steady_clock_test();
 extern void timeout_test();
 extern void timer_test();
+extern void servo_test();
 }  // namespace hal
 
 int main()
@@ -35,6 +36,7 @@ int main()
   hal::socket_test();
   hal::spi_test();
   hal::steady_clock_test();
+  hal::servo_test();
   hal::timeout_test();
   hal::timer_test();
 

--- a/tests/servo.test.cpp
+++ b/tests/servo.test.cpp
@@ -1,0 +1,73 @@
+#include <libhal/servo.hpp>
+
+#include <boost/ut.hpp>
+
+namespace hal {
+namespace {
+constexpr auto expected_value = hal::degrees(45);
+constexpr auto min_range = hal::degrees(-90);
+constexpr auto max_range = hal::degrees(+90);
+
+class test_servo : public hal::servo
+{
+public:
+  hal::degrees m_position = 0.0f;
+
+  ~test_servo()
+  {
+  }
+
+private:
+  result<position_t> driver_position(hal::degrees p_position) override
+  {
+    bool in_range = min_range < p_position && p_position < max_range;
+    if (!in_range) {
+      return hal::new_error(std::errc::invalid_argument,
+                            hal::servo::range_error{
+                              .min = min_range,
+                              .max = max_range,
+                            });
+    }
+
+    m_position = p_position;
+
+    return position_t{};
+  };
+};
+}  // namespace
+
+void servo_test()
+{
+  using namespace boost::ut;
+  "servo interface test"_test = []() {
+    // Setup
+    test_servo test;
+
+    // Exercise
+    auto result = test.position(expected_value);
+
+    // Verify
+    expect(bool{ result });
+    expect(that % expected_value == test.m_position);
+  };
+
+  "servo errors test"_test = []() {
+    // Setup
+    test_servo test;
+
+    // Exercise
+    hal::attempt_all(
+      [&test]() -> hal::status {
+        HAL_CHECK(test.position(max_range + 45.0f));
+        return hal::new_error();
+      },
+      // Verify
+      [](std::errc p_error_code, hal::servo::range_error p_range_error) {
+        expect(std::errc::invalid_argument == p_error_code);
+        expect(that % min_range == p_range_error.min);
+        expect(that % max_range == p_range_error.max);
+      },
+      []() { expect(false) << "None of the above errors were thrown!"; });
+  };
+};
+}  // namespace hal


### PR DESCRIPTION
- :arrow_up: bump version to 1.2.0
- :memo: Improve documentation wording in motor interface

Resolves #681