### PR TITLE
:bang: Remove result<T> from steady clock

### DIFF
--- a/include/libhal/steady_clock.hpp
+++ b/include/libhal/steady_clock.hpp
@@ -24,7 +24,12 @@ namespace hal {
  * @brief Hardware abstraction interface for a steady clock mechanism
  *
  * Implementations of this interface must follow the same requirements as a
- * std::chrono::steady_clock, in that the clock is monotonic & steady.
+ * std::chrono::steady_clock, in that the clock is monotonic & steady. An
+ * additional requirement is added to ensure that the clock is reliable. Meaning
+ * calls to the interface functions do not return errors because this clock
+ * should be infallible. To ensure this, this clock should be driven by the
+ * platform's peripheral drivers or some other mechanism that is unlikely to go
+ * offline while the platform is in a normal operating state.
  *
  * This clock is steady meaning that subsequent calls to get the uptime of this
  * clock cannot decrease as physical time moves forward and the time between
@@ -34,8 +39,7 @@ namespace hal {
  * the time when the steady clock object is created. This clock is most suitable
  * for measuring time intervals.
  *
- * After creation of the clock, the operating frequency will not change.
- *
+ * After creation of this clock, the operating frequency shall not change.
  */
 class steady_clock
 {
@@ -74,7 +78,7 @@ public:
    * @return result<frequency_t> - operating frequency of the steady clock.
    * Guaranteed to be a positive value by the implementing driver.
    */
-  [[nodiscard]] result<frequency_t> frequency()
+  [[nodiscard]] frequency_t frequency()
   {
     return driver_frequency();
   }
@@ -82,9 +86,9 @@ public:
   /**
    * @brief Get the current value of the steady clock
    *
-   * @return result<uptime_t> - uptime information
+   * @return uptime_t - uptime information
    */
-  [[nodiscard]] result<uptime_t> uptime()
+  [[nodiscard]] uptime_t uptime()
   {
     return driver_uptime();
   }
@@ -92,7 +96,7 @@ public:
   virtual ~steady_clock() = default;
 
 private:
-  virtual result<frequency_t> driver_frequency() = 0;
-  virtual result<uptime_t> driver_uptime() = 0;
+  virtual frequency_t driver_frequency() = 0;
+  virtual uptime_t driver_uptime() = 0;
 };
 }  // namespace hal

--- a/tests/steady_clock.test.cpp
+++ b/tests/steady_clock.test.cpp
@@ -23,23 +23,19 @@ class test_steady_clock : public hal::steady_clock
 public:
   constexpr static hertz m_frequency{ 1.0_Hz };
   constexpr static std::uint64_t m_uptime{ 100 };
-  bool m_return_error_status{ false };
 
   ~test_steady_clock()
   {
   }
 
 private:
-  result<frequency_t> driver_frequency() override
+  frequency_t driver_frequency() override
   {
     return frequency_t{ .operating_frequency = m_frequency };
   };
 
-  result<uptime_t> driver_uptime() override
+  uptime_t driver_uptime() override
   {
-    if (m_return_error_status) {
-      return hal::new_error();
-    }
     return uptime_t{ .ticks = m_uptime };
   };
 };
@@ -57,21 +53,8 @@ void steady_clock_test()
     auto result2 = test.uptime();
 
     // Verify
-    expect(that % test.m_frequency == result1.value().operating_frequency);
-    expect(bool{ result2 });
-    expect(that % test.m_uptime == result2.value().ticks);
-  };
-
-  "steady_clock errors test"_test = []() {
-    // Setup
-    test_steady_clock test;
-    test.m_return_error_status = true;
-
-    // Exercise
-    auto result = test.uptime();
-
-    // Verify
-    expect(!bool{ result });
+    expect(that % test.m_frequency == result1.operating_frequency);
+    expect(that % test.m_uptime == result2.ticks);
   };
 };
 }  // namespace hal


### PR DESCRIPTION
Version number will remain 2.0.0 as no users are currently using the software. The previous version will be purged from the server.

This is to improve guarantees around steady clock, improve performance, and reduce code verbosity.