### PR TITLE
:construction_worker: Use ci/4.x.y version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
   release:
-    types: [published]
+    types:
+      - published
+      - deleted
   push:
     branches:
       - main
@@ -13,5 +15,5 @@ on:
 
 jobs:
   ci:
-    uses: libhal/ci/.github/workflows/library.yml@4.1.0
+    uses: libhal/ci/.github/workflows/library.yml@4.x.y
     secrets: inherit


### PR DESCRIPTION
The 4.x.y branch scheme means that this repo will get the latest changes to the ci that does not include breaking changes.