### PR TITLE
:arrow_up: Use boost/1.83.0 vs boost-leaf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,9 @@ libhal_unit_test(SOURCES
   tests/main.test.cpp
 
   PACKAGES
-  boost-leaf
+  Boost
   tl-function-ref
 
   LINK_LIBRARIES
-  boost::leaf
+  Boost::headers
   tl::function-ref)

--- a/conanfile.py
+++ b/conanfile.py
@@ -65,7 +65,10 @@ class libhal_conan(ConanFile):
 
     def requirements(self):
         self.requires("tl-function-ref/1.0.0")
-        self.requires("boost-leaf/1.81.0")
+        self.requires("boost/1.83.0", transitive_headers=True,
+                      options={
+                          "header_only": True,
+                        })
 
     def layout(self):
         cmake_layout(self)

--- a/include/libhal/error.hpp
+++ b/include/libhal/error.hpp
@@ -14,8 +14,9 @@
 
 #pragma once
 
-#include <boost/leaf.hpp>
 #include <system_error>
+
+#include <boost/leaf/detail/all.hpp>
 
 #define HAL_CHECK BOOST_LEAF_CHECK
 


### PR DESCRIPTION
Use boost library directly just to get boost-leaf. This does work and doesn't require all of the additional requirements to be built.