### PR TITLE
:arrow_up: Release version to 2.0.2

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_conan(ConanFile):
     name = "libhal"
-    version = "2.0.1"
+    version = "2.0.2"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal"


### PR DESCRIPTION
- Major change, uses boost directly and not boost-leaf.